### PR TITLE
Update to rust-bitcoin v0.19.1, add encode module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,13 @@ documentation = "https://docs.rs/elements/"
 
 [features]
 "serde-feature" = [
-    "bitcoin/serde",
-    "bitcoin_hashes/serde",
+    "bitcoin/use-serde",
     "serde"
 ]
 "fuzztarget" = []
 
 [dependencies]
-bech32 = "0.6"
-bitcoin_hashes = "0.3.0"
-secp256k1 = "0.12.0"
-
-[dependencies.bitcoin]
-version = "0.18.0"
+bitcoin = "0.19.1"
 
 [dependencies.serde]
 version = "1.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,9 +16,6 @@ honggfuzz = { version = "0.5", optional = true }
 afl = { version = "0.3", optional = true }
 elements = { path = "..", features = ["fuzztarget", "serde-feature"] }
 
-[dependencies.bitcoin]
-version = "0.18"
-
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/fuzz/fuzz_targets/deserialize_block.rs
+++ b/fuzz/fuzz_targets/deserialize_block.rs
@@ -1,13 +1,12 @@
 
-extern crate bitcoin;
 extern crate elements;
 
 fn do_test(data: &[u8]) {
-    let block_result: Result<elements::Block, _> = bitcoin::consensus::deserialize(data);
+    let block_result: Result<elements::Block, _> = elements::encode::deserialize(data);
     match block_result {
         Err(_) => {},
         Ok(block) => {
-            let reser = bitcoin::consensus::serialize(&block);
+            let reser = elements::encode::serialize(&block);
             assert_eq!(data, &reser[..]);
         },
     }

--- a/fuzz/fuzz_targets/deserialize_output.rs
+++ b/fuzz/fuzz_targets/deserialize_output.rs
@@ -1,13 +1,12 @@
 
-extern crate bitcoin;
 extern crate elements;
 
 fn do_test(data: &[u8]) {
-    let result: Result<elements::TxOut, _> = bitcoin::consensus::encode::deserialize(data);
+    let result: Result<elements::TxOut, _> = elements::encode::deserialize(data);
     match result {
         Err(_) => {},
         Ok(output) => {
-            let reser = bitcoin::consensus::encode::serialize(&output);
+            let reser = elements::encode::serialize(&output);
             assert_eq!(data, &reser[..]);
 
             output.is_null_data();

--- a/fuzz/fuzz_targets/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/deserialize_transaction.rs
@@ -1,13 +1,12 @@
 
-extern crate bitcoin;
 extern crate elements;
 
 fn do_test(data: &[u8]) {
-    let tx_result: Result<elements::Transaction, _> = bitcoin::consensus::deserialize(data);
+    let tx_result: Result<elements::Transaction, _> = elements::encode::deserialize(data);
     match tx_result {
         Err(_) => {},
         Ok(mut tx) => {
-            let reser = bitcoin::consensus::serialize(&tx);
+            let reser = elements::encode::serialize(&tx);
             assert_eq!(data, &reser[..]);
             let len = reser.len();
             let calculated_weight = tx.get_weight();
@@ -18,7 +17,7 @@ fn do_test(data: &[u8]) {
                 output.witness = elements::TxOutWitness::default();
             }
             assert_eq!(tx.has_witness(), false);
-            let no_witness_len = bitcoin::consensus::serialize(&tx).len();
+            let no_witness_len = elements::encode::serialize(&tx).len();
             assert_eq!(no_witness_len * 3 + len, calculated_weight);
 
             for output in &tx.output {

--- a/src/blech32.rs
+++ b/src/blech32.rs
@@ -46,7 +46,7 @@ use std::fmt;
 #[allow(unused_imports, deprecated)]
 use std::ascii::AsciiExt;
 
-use bech32::{u5, Error};
+use bitcoin::bech32::{u5, Error};
 
 /// Encode a bech32 payload to an [fmt::Formatter].
 pub fn encode_to_fmt<T: AsRef<[u5]>>(fmt: &mut fmt::Formatter, hrp: &str, data: T) -> fmt::Result {
@@ -235,7 +235,7 @@ const GEN: [u64; 5] = [
 mod test {
     use super::*;
 
-    use bech32::ToBase32;
+    use bitcoin::bech32::ToBase32;
     use rand;
 
     #[test]

--- a/src/block.rs
+++ b/src/block.rs
@@ -17,7 +17,7 @@
 
 use bitcoin::blockdata::script::Script;
 use bitcoin::BitcoinHash;
-use bitcoin_hashes::{Hash, sha256d};
+use bitcoin::hashes::{Hash, sha256d};
 
 use Transaction;
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,0 +1,188 @@
+// Rust Elements Library
+// Written in 2018 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Consensus-encodable types
+//!
+
+use std::io::Cursor;
+use std::{error, fmt, io, mem};
+
+use ::bitcoin::consensus::encode as btcenc;
+
+use transaction::{Transaction, TxIn, TxOut};
+
+/// Encoding error
+#[derive(Debug)]
+pub enum Error {
+    /// A Bitcoin encoding error.
+    Bitcoin(btcenc::Error),
+    /// Tried to allocate an oversized vector
+    OversizedVectorAllocation {
+        /// The capacity requested
+        requested: usize,
+        /// The maximum capacity
+        max: usize,
+    },
+    /// Parsing error
+    ParseFailed(&'static str),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Bitcoin(ref e) => write!(f, "a Bitcoin type encoding error: {}", e),
+            Error::OversizedVectorAllocation {
+                requested: ref r,
+                max: ref m,
+            } => write!(f, "oversized vector allocation: requested {}, maximum {}", r, m),
+            Error::ParseFailed(ref e) => write!(f, "parse failed: {}", e),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Bitcoin(ref e) => Some(e),
+            _ => None,
+        }
+    }
+
+    fn description(&self) -> &str {
+        "an Elements encoding error"
+    }
+}
+
+#[doc(hidden)]
+impl From<btcenc::Error> for Error {
+    fn from(e: btcenc::Error) -> Error {
+        Error::Bitcoin(e)
+    }
+}
+
+/// Data which can be encoded in a consensus-consistent way
+pub trait Encodable {
+    /// Encode an object with a well-defined format, should only ever error if
+    /// the underlying `Write` errors. Returns the number of bytes written on
+    /// success
+    fn consensus_encode<W: io::Write>(&self, e: W) -> Result<usize, Error>;
+}
+
+/// Data which can be encoded in a consensus-consistent way
+pub trait Decodable: Sized {
+    /// Decode an object with a well-defined format
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, Error>;
+}
+
+/// Encode an object into a vector
+pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
+    let mut encoder = Cursor::new(vec![]);
+    data.consensus_encode(&mut encoder).unwrap();
+    encoder.into_inner()
+}
+
+/// Encode an object into a hex-encoded string
+pub fn serialize_hex<T: Encodable + ?Sized>(data: &T) -> String {
+    ::bitcoin::hashes::hex::ToHex::to_hex(&serialize(data)[..])
+}
+
+/// Deserialize an object from a vector, will error if said deserialization
+/// doesn't consume the entire vector.
+pub fn deserialize<'a, T: Decodable>(data: &'a [u8]) -> Result<T, Error> {
+    let (rv, consumed) = deserialize_partial(data)?;
+
+    // Fail if data are not consumed entirely.
+    if consumed == data.len() {
+        Ok(rv)
+    } else {
+        Err(Error::ParseFailed("data not consumed entirely when explicitly deserializing"))
+    }
+}
+
+/// Deserialize an object from a vector, but will not report an error if said deserialization
+/// doesn't consume the entire vector.
+pub fn deserialize_partial<'a, T: Decodable>(data: &'a [u8]) -> Result<(T, usize), Error> {
+    let mut decoder = Cursor::new(data);
+    let rv = Decodable::consensus_decode(&mut decoder)?;
+    let consumed = decoder.position() as usize;
+
+    Ok((rv, consumed))
+}
+
+/// Implement Elements encodable traits for Bitcoin encodable types.
+macro_rules! impl_upstream {
+    ($type: ty) => {
+        impl Encodable for $type {
+            fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, Error> {
+                Ok(btcenc::Encodable::consensus_encode(self, &mut e)?)
+            }
+        }
+
+        impl Decodable for $type {
+            fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+                Ok(btcenc::Decodable::consensus_decode(&mut d)?)
+            }
+        }
+    };
+}
+impl_upstream!(u8);
+impl_upstream!(u32);
+impl_upstream!(u64);
+impl_upstream!([u8; 32]);
+impl_upstream!(Vec<u8>);
+impl_upstream!(Vec<Vec<u8>>);
+impl_upstream!(btcenc::VarInt);
+impl_upstream!(::bitcoin::blockdata::script::Script);
+impl_upstream!(::bitcoin::hashes::sha256d::Hash);
+
+// Vectors
+macro_rules! impl_vec {
+    ($type: ty) => {
+        impl Encodable for Vec<$type> {
+            #[inline]
+            fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, Error> {
+                let mut len = 0;
+                len += btcenc::VarInt(self.len() as u64).consensus_encode(&mut s)?;
+                for c in self.iter() {
+                    len += c.consensus_encode(&mut s)?;
+                }
+                Ok(len)
+            }
+        }
+
+        impl Decodable for Vec<$type> {
+            #[inline]
+            fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+                let len = btcenc::VarInt::consensus_decode(&mut d)?.0;
+                let byte_size = (len as usize)
+                    .checked_mul(mem::size_of::<$type>())
+                    .ok_or(self::Error::ParseFailed("Invalid length"))?;
+                if byte_size > btcenc::MAX_VEC_SIZE {
+                    return Err(self::Error::OversizedVectorAllocation {
+                        requested: byte_size,
+                        max: btcenc::MAX_VEC_SIZE,
+                    });
+                }
+                let mut ret = Vec::with_capacity(len as usize);
+                for _ in 0..len {
+                    ret.push(Decodable::consensus_decode(&mut d)?);
+                }
+                Ok(ret)
+            }
+        }
+    };
+}
+impl_vec!(TxIn);
+impl_vec!(TxOut);
+impl_vec!(Transaction);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,7 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
-extern crate bech32;
 extern crate bitcoin;
-extern crate bitcoin_hashes;
-extern crate secp256k1;
 #[cfg(feature = "serde")] extern crate serde;
 
 #[cfg(test)] extern crate rand;
@@ -39,6 +36,7 @@ pub mod address;
 pub mod blech32;
 mod block;
 pub mod confidential;
+pub mod encode;
 mod transaction;
 
 // export everything at the top level so it can be used as `elements::Transaction` etc.


### PR DESCRIPTION
This adds an `Encodable` and `Decodable` trait for Elements types. It implements those traits for some rust-bitcoin types using the `bitcoin::consensus::Encodable` counterpart of those types.

This was needed because rust-bitcoin no longer implements `Encodable` generically for `Vec<T>`, so we couldn't encode vectors of our own types without making newtypes for them. And it's probably better like this anyway. Fairly little code duplication.