### PR TITLE
Export bitcoin dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elements"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Andrew Poelstra <apoelstra@blockstream.com>"]
 description = "Library with support for de/serialization, parsing and executing on data structures and network messages related to Elements"
 license = "CC0-1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
-extern crate bitcoin;
+pub extern crate bitcoin;
 #[cfg(feature = "serde")] extern crate serde;
 
 #[cfg(test)] extern crate rand;


### PR DESCRIPTION
We use the rust-bitcoin types. I know we should in the long term move away from that, but for now we still have several of the types that we reuse.