### PR TITLE
Add Params::elided_root and Params::into_compact

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elements"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Andrew Poelstra <apoelstra@blockstream.com>"]
 description = "Library with support for de/serialization, parsing and executing on data structures and network messages related to Elements"
 license = "CC0-1.0"

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -129,6 +129,15 @@ impl Params {
         }
     }
 
+    /// Get the elided_root. Is [None] for non-[Compact] params.
+    pub fn elided_root(&self) -> Option<&sha256::Midstate> {
+        match *self {
+            Params::Null => None,
+            Params::Compact { ref elided_root, ..} => Some(elided_root),
+            Params::Full { .. } => None,
+        }
+    }
+
     /// Calculate the root of this [Params].
     pub fn calculate_root(&self) -> sha256::Midstate {
         fn serialize_hash<E: Encodable>(obj: &E) -> sha256d::Hash {

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -529,4 +529,20 @@ mod tests {
             "113160f76dc17fe367a2def79aefe06feeea9c795310c9e88aeedc23e145982e"
         );
     }
+
+    #[test]
+    fn into_compact_test() {
+        let full = Params::Full {
+            signblockscript: vec![0x01, 0x02].into(),
+            signblock_witness_limit: 3,
+            fedpeg_program: vec![0x04, 0x05].into(),
+            fedpegscript: vec![0x06, 0x07],
+            extension_space: vec![vec![0x08, 0x09], vec![0x0a]],
+        };
+        let extra_root = full.extra_root();
+
+        let compact = full.into_compact().unwrap();
+        assert_eq!(compact.elided_root(), Some(&extra_root));
+        assert_eq!(compact.extra_root(), extra_root);
+    }
 }


### PR DESCRIPTION
Sorry, I should have noticed this was missing while reviewing the PR that added the elided_root field. There are getters for all the other fields, so we should probably have this one. I already bumped into missing this one.