### PR TITLE
Export bitcoin's hash newtypes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elements"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Andrew Poelstra <apoelstra@blockstream.com>"]
 description = "Library with support for de/serialization, parsing and executing on data structures and network messages related to Elements"
 license = "CC0-1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,10 @@ mod fast_merkle_root;
 pub mod issuance;
 mod transaction;
 
+// Re-export all the hash newtypes that bitcoin specifies because they are not identical
+// semantically.
+pub use bitcoin::hash_types::*;
+
 // export everything at the top level so it can be used as `elements::Transaction` etc.
 pub use address::{Address, AddressParams, AddressError};
 pub use transaction::{OutPoint, PeginData, PegoutData, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};


### PR DESCRIPTION
They are semantically different, so we should provide them here.

I'm not 100% sure about this, though. Because they are still exchangeable, just "symlinks".