### PR TITLE
Use AssetId as inner type for confidential::Asset

### DIFF
--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -25,6 +25,7 @@ use std::{io, fmt};
 use bitcoin::hashes::sha256d;
 
 use encode::{self, Encodable, Decodable};
+use issuance::AssetId;
 
 // Helper macro to implement various things for the various confidential
 // commitment types
@@ -207,7 +208,7 @@ pub enum Asset {
     /// No value
     Null,
     /// Asset entropy is explicitly encoded
-    Explicit(sha256d::Hash),
+    Explicit(AssetId),
     /// Asset is committed
     Confidential(u8, [u8; 32]),
 }
@@ -233,7 +234,7 @@ impl Asset {
 
     /// Returns the explicit asset.
     /// Returns [None] if [is_explicit] returns false.
-    pub fn explicit(&self) -> Option<sha256d::Hash> {
+    pub fn explicit(&self) -> Option<AssetId> {
         match *self {
             Asset::Explicit(v) => Some(v),
             _ => None,
@@ -286,7 +287,7 @@ impl Nonce {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::hashes::Hash;
+    use bitcoin::hashes::{Hash, sha256};
     use super::*;
 
     #[test]
@@ -315,7 +316,7 @@ mod tests {
 
         let assets = [
             Asset::Null,
-            Asset::Explicit(sha256d::Hash::from_inner([0; 32])),
+            Asset::Explicit(AssetId::from_inner(sha256::Midstate::from_inner([0; 32]))),
             Asset::Confidential(0x0a, [1; 32]),
         ];
         for v in &assets[..] {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -18,11 +18,12 @@
 use std::io::Cursor;
 use std::{error, fmt, io, mem};
 
-use ::bitcoin::consensus::encode as btcenc;
+use bitcoin::consensus::encode as btcenc;
+use bitcoin::hashes::sha256;
 
 use transaction::{Transaction, TxIn, TxOut};
 
-pub use ::bitcoin::consensus::encode::MAX_VEC_SIZE;
+pub use bitcoin::consensus::encode::MAX_VEC_SIZE;
 
 /// Encoding error
 #[derive(Debug)]
@@ -120,6 +121,18 @@ pub fn deserialize_partial<'a, T: Decodable>(data: &'a [u8]) -> Result<(T, usize
     let consumed = decoder.position() as usize;
 
     Ok((rv, consumed))
+}
+
+impl Encodable for sha256::Midstate {
+    fn consensus_encode<W: io::Write>(&self, e: W) -> Result<usize, Error> {
+        self.into_inner().consensus_encode(e)
+    }
+}
+
+impl Decodable for sha256::Midstate {
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, Error> {
+        Ok(Self::from_inner(<[u8; 32]>::consensus_decode(d)?))
+    }
 }
 
 /// Implement Elements encodable traits for Bitcoin encodable types.

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -14,10 +14,13 @@
 
 //! Asset Issuance
 
+use std::io;
 use std::str::FromStr;
 
 use bitcoin::util::hash::BitcoinHash;
 use bitcoin::hashes::{hex, sha256, Hash};
+
+use encode::{self, Encodable, Decodable};
 use fast_merkle_root::fast_merkle_root;
 use transaction::OutPoint;
 
@@ -117,6 +120,18 @@ impl FromStr for AssetId {
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		hex::FromHex::from_hex(s)
 	}
+}
+
+impl Encodable for AssetId {
+    fn consensus_encode<W: io::Write>(&self, e: W) -> Result<usize, encode::Error> {
+        self.0.consensus_encode(e)
+    }
+}
+
+impl Decodable for AssetId {
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+        Ok(Self::from_inner(sha256::Midstate::consensus_decode(d)?))
+    }
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Follows on https://github.com/ElementsProject/rust-elements/pull/45.

The current inner type is just plain wrong. It's `sha256::Midstate` in theory.