### PR TITLE
Confidential improvements

### DIFF
--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -82,10 +82,11 @@ macro_rules! impl_confidential_commitment {
                         let explicit = $explicit_fn(Decodable::consensus_decode(&mut d)?);
                         Ok($name::Explicit(explicit))
                     }
-                    x => {
+                    p if p == $prefixA || p == $prefixB => {
                         let commitment = <[u8; 32]>::consensus_decode(&mut d)?;
-                        Ok($name::Confidential(x, commitment))
+                        Ok($name::Confidential(p, commitment))
                     }
+                    p => return Err(encode::Error::InvalidConfidentialPrefix(p)),
                 }
             }
         }
@@ -143,12 +144,15 @@ macro_rules! impl_confidential_commitment {
                                     None => Err(A::Error::custom("missing commitment")),
                                 }
                             }
-                            x => {
+                            p if p == $prefixA || p == $prefixB => {
                                 match access.next_element()? {
-                                    Some(y) => Ok($name::Confidential(x, y)),
+                                    Some(y) => Ok($name::Confidential(p, y)),
                                     None => Err(A::Error::custom("missing commitment")),
                                 }
                             }
+                            p => return Err(A::Error::custom(format!(
+                                "invalid commitment, invalid prefix: 0x{:02x}", p
+                            ))),
                         }
                     }
                 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -39,6 +39,8 @@ pub enum Error {
     },
     /// Parsing error
     ParseFailed(&'static str),
+    /// Invalid prefix for the confidential type.
+    InvalidConfidentialPrefix(u8),
 }
 
 impl fmt::Display for Error {
@@ -50,6 +52,7 @@ impl fmt::Display for Error {
                 max: ref m,
             } => write!(f, "oversized vector allocation: requested {}, maximum {}", r, m),
             Error::ParseFailed(ref e) => write!(f, "parse failed: {}", e),
+            Error::InvalidConfidentialPrefix(p) => write!(f, "invalid confidential prefix: 0x{:02x}", p),
         }
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1562,7 +1562,7 @@ mod tests {
     fn txout_null_data() {
         // Output with high opcodes should not be considered nulldata
         let output: TxOut = hex_deserialize!("\
-            c3319c0000000000d3d3d3d3d3d3d3d3d3d3d3d3fdfdfd0101010101010101010\
+            0a319c0000000000d3d3d3d3d3d3d3d3d3d3d3d3fdfdfd0101010101010101010\
             101010101010101010101010101012e010101010101010101fdfdfdfdfdfdfdfd\
             fdfdfdfdfdfdfdfdfdfdfdfd006a209f6a6a6a6a6a6a806a6afdfdfdfd17fdfdf\
             dfdfdfdfdfdfdfdddfdfdfdfdfdfdfdfdfddedededededededededededededede\
@@ -1580,7 +1580,7 @@ mod tests {
 
         // Output with pushes that are e.g. OP_1 are nulldata but not pegouts
         let output: TxOut = hex_deserialize!("\
-            c32d3634393536d9a2d0aaba3823f442fb24363831fdfd0101010101010101010\
+            0a2d3634393536d9a2d0aaba3823f442fb24363831fdfd0101010101010101010\
             1010101010101010101010101010101010101016a01010101fdfdfdfdfdfdfdfd\
             fdfdfdfdfd3ca059fdfdfb6a2000002323232323232323232323232323232\
             3232323232323232321232323010151232323232323232323232323232323\
@@ -1598,7 +1598,7 @@ mod tests {
 
         // Output with just one push and nothing else should be nulldata but not pegout
         let output: TxOut = hex_deserialize!("\
-            c32d3634393536d9a2d0aaba3823f442fb24363831fdfd0101010101010101010\
+            0a2d3634393536d9a2d0aaba3823f442fb24363831fdfd0101010101010101010\
             1010101010101010101010101010101010101016a01010101fdfdfdfdfdfdfdfd\
             fdfdfdfdfd3ca059fdf2226a20000000000000000000000000000000000000000\
             0000000000000000000000000\


### PR DESCRIPTION
Solves https://github.com/ElementsProject/rust-elements/issues/18: enforce correct commitment prefixes.

Also replaces the `confidential::Nonce` inner value with `[u8; 32]` because it's not a `sha256d::Hash`. I'm not sure if this will cause any problem anywhere because they are not displayed the same way.

Plus some other improvements.