### PR TITLE
Add support for hashing JSON asset contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/ElementsProject/rust-elements/"
 documentation = "https://docs.rs/elements/"
 
 [features]
+default = [ "json-contract" ]
+
+json-contract = [ "serde_json" ]
 "serde-feature" = [
     "bitcoin/use-serde",
     "serde"
@@ -21,6 +24,9 @@ bitcoin = "0.23"
 # We should probably try keep this one in sync with the bitcoin version,
 # to avoid requiring two version of bitcoin_hashes.
 bitcoin_hashes = "0.7.6"
+
+# Used for ContractHash::from_json_contract.
+serde_json = { version = "<=1.0.44", optional = true }
 
 [dependencies.serde]
 version = "1.0"

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -39,6 +39,26 @@ const TWO32: [u8; 32] = [
 
 hash_newtype!(ContractHash, sha256::Hash, 32, doc="The hash of an asset contract.", true);
 
+impl ContractHash {
+    /// Calculate the contract hash of a JSON contract object.
+    ///
+    /// This method does not perform any validation of the contents of the contract.
+    /// After basic JSON syntax validation, the object is formatted in a standard way to calculate
+    /// the hash.
+    #[cfg(feature = "json-contract")]
+    pub fn from_json_contract(json: &str) -> Result<ContractHash, ::serde_json::Error> {
+        // Parsing the JSON into a BTreeMap will recursively order object keys
+        // lexicographically. This order is respected when we later serialize
+        // it again.
+        let ordered: ::std::collections::BTreeMap<String, ::serde_json::Value> =
+            ::serde_json::from_str(json)?;
+
+        let mut engine = ContractHash::engine();
+        ::serde_json::to_writer(&mut engine, &ordered).expect("engines don't error");
+        Ok(ContractHash::from_engine(engine))
+    }
+}
+
 /// An issued asset ID.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 pub struct AssetId(sha256::Midstate);
@@ -241,5 +261,35 @@ mod test {
         assert_eq!(AssetId::from_entropy(entropy), asset_id);
         let token_id = AssetId::from_hex(token_id_hex).unwrap();
         assert_eq!(AssetId::reissuance_token_from_entropy(entropy, false), token_id);
+    }
+
+    #[cfg(feature = "json-contract")]
+    #[test]
+    fn test_json_contract() {
+        let tether = ContractHash::from_hex("3c7f0a53c2ff5b99590620d7f6604a7a3a7bfbaaa6aa61f7bfc7833ca03cde82").unwrap();
+
+        let correct = r#"{"entity":{"domain":"tether.to"},"issuer_pubkey":"0337cceec0beea0232ebe14cba0197a9fbd45fcf2ec946749de920e71434c2b904","name":"Tether USD","precision":8,"ticker":"USDt","version":0}"#;
+        let expected = ContractHash::hash(correct.as_bytes());
+        assert_eq!(tether, expected);
+        assert_eq!(expected, ContractHash::from_json_contract(&correct).unwrap());
+
+        let invalid_json = r#"{"entity":{"domain":"tether.to"},"issuer_pubkey:"#;
+        assert!(ContractHash::from_json_contract(&invalid_json).is_err());
+
+        let unordered = r#"{"precision":8,"ticker":"USDt","entity":{"domain":"tether.to"},"issuer_pubkey":"0337cceec0beea0232ebe14cba0197a9fbd45fcf2ec946749de920e71434c2b904","name":"Tether USD","version":0}"#;
+        assert_eq!(expected, ContractHash::from_json_contract(&unordered).unwrap());
+
+        let unordered = r#"{"precision":8,"name":"Tether USD","ticker":"USDt","entity":{"domain":"tether.to"},"issuer_pubkey":"0337cceec0beea0232ebe14cba0197a9fbd45fcf2ec946749de920e71434c2b904","version":0}"#;
+        assert_eq!(expected, ContractHash::from_json_contract(&unordered).unwrap());
+
+        let spaces = r#"{"precision":8, "name" : "Tether USD", "ticker":"USDt",  "entity":{"domain":"tether.to" }, "issuer_pubkey" :"0337cceec0beea0232ebe14cba0197a9fbd45fcf2ec946749de920e71434c2b904","version":0} "#;
+        assert_eq!(expected, ContractHash::from_json_contract(&spaces).unwrap());
+
+        let nested_correct = r#"{"entity":{"author":"Tether Inc","copyright":2020,"domain":"tether.to","hq":"Mars"},"issuer_pubkey":"0337cceec0beea0232ebe14cba0197a9fbd45fcf2ec946749de920e71434c2b904","name":"Tether USD","precision":8,"ticker":"USDt","version":0}"#;
+        let nested_expected = ContractHash::hash(nested_correct.as_bytes());
+        assert_eq!(nested_expected, ContractHash::from_json_contract(&nested_correct).unwrap());
+
+        let nested_unordered = r#"{"ticker":"USDt","entity":{"domain":"tether.to","hq":"Mars","author":"Tether Inc","copyright":2020},"issuer_pubkey":"0337cceec0beea0232ebe14cba0197a9fbd45fcf2ec946749de920e71434c2b904","name":"Tether USD","precision":8,"version":0}"#;
+        assert_eq!(nested_expected, ContractHash::from_json_contract(&nested_unordered).unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub extern crate bitcoin_hashes;
 #[cfg(feature = "serde")] extern crate serde;
 
 #[cfg(test)] extern crate rand;
-#[cfg(test)] extern crate serde_json;
+#[cfg(any(test, feature = "serde_json"))] extern crate serde_json;
 
 #[macro_use] mod internal_macros;
 pub mod address;


### PR DESCRIPTION
Annoyingly this takes 2 extra dependencies. I made them optional, but default.