### PR TITLE
Increase bitcoin dep to 0.25.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,15 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.22.0
+  - 1.29.0
 
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y binutils-dev libunwind8-dev
 
 script:
-  # The standard linker fails to link the fuzzing infrastructure but
-  # gold seems to handle it.
-  # See https://github.com/rust-lang/rust/issues/53945
-  - export RUSTFLAGS='-Clink-arg=-fuse-ld=gold'
+  # Pin `cc` for Rust 1.29
+  - if [ "$TRAVIS_RUST_VERSION" = "1.29.0" ]; then cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose; fi
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --verbose --features=serde-feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ json-contract = [ "serde_json" ]
 "fuzztarget" = []
 
 [dependencies]
-bitcoin = "0.23"
+bitcoin = "0.25"
 slip21 = "0.2.0"
 
 # While this dependency is included in bitcoin, we need this to use the macros.
 # We should probably try keep this one in sync with the bitcoin version,
 # to avoid requiring two version of bitcoin_hashes.
-bitcoin_hashes = "0.7.6"
+bitcoin_hashes = "0.9.0"
 
 # Used for ContractHash::from_json_contract.
 serde_json = { version = "<=1.0.44", optional = true }
@@ -37,3 +37,4 @@ optional = true
 [dev-dependencies]
 rand = "0.6.5"
 serde_json = "<=1.0.44"
+ryu = "<1.0.5"

--- a/src/block.rs
+++ b/src/block.rs
@@ -19,7 +19,7 @@ use std::io;
 
 use bitcoin;
 use bitcoin::blockdata::script::Script;
-use bitcoin::{BitcoinHash, BlockHash, VarInt};
+use bitcoin::{BlockHash, VarInt};
 use bitcoin::hashes::{Hash, sha256};
 #[cfg(feature = "serde")] use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")] use std::fmt;
@@ -314,8 +314,9 @@ impl Decodable for BlockHeader {
     }
 }
 
-impl BitcoinHash<BlockHash> for BlockHeader {
-    fn bitcoin_hash(&self) -> BlockHash {
+impl BlockHeader {
+    /// Return the block hash.
+    pub fn block_hash(&self) -> BlockHash {
 
         let version = if let ExtData::Dynafed { .. } = self.ext {
             self.version | 0x8000_0000
@@ -371,16 +372,15 @@ impl Block {
     }
 }
 
-impl BitcoinHash<BlockHash> for Block {
-    fn bitcoin_hash(&self) -> BlockHash {
-        self.header.bitcoin_hash()
+impl Block {
+    /// Return the block hash.
+    pub fn block_hash(&self) -> BlockHash {
+        self.header.block_hash()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::BitcoinHash;
-
     use Block;
 
     use super::*;
@@ -402,7 +402,7 @@ mod tests {
         );
 
         assert_eq!(
-            block.bitcoin_hash().to_string(),
+            block.block_hash().to_string(),
             "287ca47e8da47eb8c28d870663450bb026922eadb30a1b2f8293e6e9d1ca5322"
         );
         assert_eq!(block.header.version, 0x20000000);
@@ -614,7 +614,7 @@ mod tests {
         );
 
         assert_eq!(
-            block.bitcoin_hash().to_string(),
+            block.block_hash().to_string(),
             "e935d06cf3a616eb4d551338598b84daa0e8592ed14673263597f6af4b4a6ea6"
         );
         assert_eq!(block.header.version, 0x20000000);
@@ -645,7 +645,7 @@ mod tests {
         );
 
         assert_eq!(
-            block.bitcoin_hash().to_string(),
+            block.block_hash().to_string(),
             "bcc6eb2ab6c97b9b4590825b9136f100b22e090c0469818572b8b93926a79f28"
         );
         assert_eq!(block.header.version, 0x20000000);
@@ -700,7 +700,7 @@ mod tests {
         }
 
         assert_eq!(
-            block.bitcoin_hash().to_string(),
+            block.block_hash().to_string(),
             "4961df970cf12d789383974e6ab439f780d956b5a50162ca9d281362e46c605a"
         );
         assert_eq!(block.header.version, 0x20000000);
@@ -750,7 +750,7 @@ mod tests {
             panic!("No dynafed params");
         }
         assert_eq!(
-            block.bitcoin_hash().to_string(),
+            block.block_hash().to_string(),
             "e9a5176b1690a448f76fb691ab4d516e60e13a6e7a49454c62dbf0d611ffcce7"
         );
     }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -17,7 +17,6 @@
 use std::io;
 use std::str::FromStr;
 
-use bitcoin::util::hash::BitcoinHash;
 use bitcoin::hashes::{self, hex, sha256, Hash};
 
 use encode::{self, Encodable, Decodable};
@@ -88,7 +87,7 @@ impl AssetId {
         // I : prevout
         // C : contract
         // E = H( H(I) || H(C) )
-        fast_merkle_root(&[prevout.bitcoin_hash().into_inner(), contract_hash.into_inner()])
+        fast_merkle_root(&[prevout.hash().into_inner(), contract_hash.into_inner()])
     }
 
     /// Calculate the asset ID from the asset entropy.


### PR DESCRIPTION
* increase bitcoin_hashes dep accordingly
* remove BitcoinHash and use block_hash for block and header
* ~~remove std Error impl since MSVR increased and it's not necessary anymore~~
* ~~run cargo fmt, should have been a separate commit~~
* use instrunctions() iterator instead of iter(false)
* pin cc dep to 1.0.41 for travis 1.0.29 build
* removes, export RUSTFLAGS='-Clink-arg=-fuse-ld=gold' seems no longer necessary

~~Made several attempts to fix CI build with rust version 1.29.0 however it breaks trying to use cc dep `1.0.60` but I didn't find a way to use a lower version, any idea?~~