### PR TITLE
Improve the dynafed::Params fmt::Debug implementation

### DIFF
--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -24,7 +24,7 @@ use encode::{self, Encodable, Decodable};
 use Script;
 
 /// Dynamic federations paramaters, as encoded in a block header
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Params {
     /// Null entry, used to signal "no vote" as a proposal
     Null,

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -75,7 +75,7 @@ impl fmt::Debug for Params {
                 write!(f, "[")?;
                 for (i, e) in self.0.iter().enumerate() {
                     if i != 0 {
-                        write!(f, " ")?;
+                        write!(f, ", ")?;
                     }
                     bitcoin::hashes::hex::format_hex(&e[..], f)?;
                 }
@@ -609,7 +609,7 @@ mod tests {
         };
         assert_eq!(
             to_debug_string(&full),
-            "Full { signblockscript: 0102, signblock_witness_limit: 3, fedpeg_program: 0405, fedpegscript: 0607, extension_space: [0809 0a] }",
+            "Full { signblockscript: 0102, signblock_witness_limit: 3, fedpeg_program: 0405, fedpegscript: 0607, extension_space: [0809, 0a] }",
         );
         let extra_root = full.extra_root();
 


### PR DESCRIPTION
The fedpegscript and witness values are Vec<u8> and displayed as arrays
of integers. This implementation changes that to show hex strings for
them instead.