### PR TITLE
Model Value, Asset and Nonce confidential variants using secp256k1-zkp types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,6 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.6.5"
+serde_test = "1.0"
 serde_json = "<=1.0.44"
 ryu = "<1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ default = [ "json-contract" ]
 json-contract = [ "serde_json" ]
 "serde-feature" = [
     "bitcoin/use-serde",
+    "secp256k1-zkp/use-serde",
     "serde"
 ]
 "fuzztarget" = []
 
 [dependencies]
 bitcoin = "0.26"
+secp256k1-zkp = { version = "0.2", features = [ "global-context", "hashes" ] }
 slip21 = "0.2.0"
 
 # While this dependency is included in bitcoin, we need this to use the macros.

--- a/src/blech32.rs
+++ b/src/blech32.rs
@@ -77,7 +77,7 @@ pub fn decode(s: &str) -> Result<(&str, Vec<u5>), Error> {
     }
 
     // Split at separator and check for two pieces
-    let (raw_hrp, raw_data) = match s.rfind("1") {
+    let (raw_hrp, raw_data) = match s.rfind('1') {
         None => return Err(Error::MissingSeparator),
         Some(sep) => {
             let (hrp, data) = s.split_at(sep);
@@ -85,7 +85,7 @@ pub fn decode(s: &str) -> Result<(&str, Vec<u5>), Error> {
         }
     };
     // ELEMENTS: 6->12
-    if raw_hrp.len() < 1 || raw_data.len() < 12 || raw_hrp.len() > 83 {
+    if raw_hrp.is_empty() || raw_data.len() < 12 || raw_hrp.len() > 83 {
         return Err(Error::InvalidLength);
     }
 
@@ -193,9 +193,9 @@ fn polymod(values: &[u5]) -> u64 {
     for v in values {
         b = (chk >> 55) as u8; // ELEMENTS: 25->55
         chk = (chk & 0x7fffffffffffff) << 5 ^ (u64::from(*v.as_ref())); // ELEMENTS 0x1ffffff->0x7fffffffffffff
-        for i in 0..5 {
+        for (i, coef) in GEN.iter().enumerate() {
             if (b >> i) & 1 == 1 {
-                chk ^= GEN[i]
+                chk ^= coef
             }
         }
     }
@@ -248,7 +248,7 @@ mod test {
 
         let data2 = data.to_vec();
         let mut data2_b32 = data2.to_base32();
-		data2_b32.extend(vec![u5::try_from_u8(0).unwrap(); 1023]);
+                data2_b32.extend(vec![u5::try_from_u8(0).unwrap(); 1023]);
         let polymod2 = polymod(&data2_b32);
         assert_eq!(polymod1, polymod2);
     }
@@ -256,7 +256,7 @@ mod test {
     #[test]
     fn test_checksum() {
         let data = vec![7,2,3,4,5,6,7,8,9,234,123,213,16];
-        let cs = create_checksum("lq".as_bytes(), &data.to_base32());
+        let cs = create_checksum(b"lq", &data.to_base32());
         let expected_cs = vec![22,13,13,5,4,4,23,7,28,21,30,12];
         for i in 0..expected_cs.len() {
             assert_eq!(expected_cs[i], *cs[i].as_ref());

--- a/src/block.rs
+++ b/src/block.rs
@@ -126,17 +126,15 @@ impl<'de> Deserialize<'de> for ExtData {
                         proposed: prop,
                         signblock_witness: wit,
                     })
+                } else if challenge_missing {
+                    Err(de::Error::missing_field("challenge"))
                 } else {
-                    if challenge_missing {
-                        Err(de::Error::missing_field("challenge"))
-                    } else {
-                        Err(de::Error::missing_field("solution"))
-                    }
+                    Err(de::Error::missing_field("solution"))
                 }
             }
         }
 
-        static FIELDS: &'static [&'static str] = &[
+        static FIELDS: &[&str] = &[
             "challenge",
             "solution",
             "current",
@@ -267,10 +265,10 @@ impl BlockHeader {
     /// the block hash.
     pub fn clear_witness(&mut self) {
         match &mut self.ext {
-            &mut ExtData::Proof { ref mut solution, .. } => {
+            ExtData::Proof { ref mut solution, .. } => {
                 *solution = Script::new();
             },
-            &mut ExtData::Dynafed { ref mut signblock_witness, .. } => {
+            ExtData::Dynafed { ref mut signblock_witness, .. } => {
                 signblock_witness.clear();
             },
         }
@@ -319,7 +317,7 @@ impl Decodable for BlockHeader {
         };
 
         Ok(BlockHeader {
-            version: version,
+            version,
             prev_blockhash: Decodable::consensus_decode(&mut d)?,
             merkle_root: Decodable::consensus_decode(&mut d)?,
             time: Decodable::consensus_decode(&mut d)?,

--- a/src/block.rs
+++ b/src/block.rs
@@ -309,7 +309,7 @@ impl Encodable for BlockHeader {
 }
 
 impl Decodable for BlockHeader {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Self, encode::Error> {
         let mut version: u32 = Decodable::consensus_decode(&mut d)?;
         let is_dyna = if version >> 31 == 1 {
             version &= 0x7fff_ffff;
@@ -749,4 +749,3 @@ mod tests {
         );
     }
 }
-

--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -17,212 +17,25 @@
 //! Structures representing Pedersen commitments of various types
 //!
 
+use secp256k1_zkp::{self, Generator, PedersenCommitment, PublicKey};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use std::{io, fmt};
+use std::{fmt, io};
 
-use encode::{self, Encodable, Decodable};
+use encode::{self, Decodable, Encodable};
 use issuance::AssetId;
 
-// Helper macro to implement various things for the various confidential
-// commitment types
-macro_rules! impl_confidential_commitment {
-    ($name:ident, $inner:ty, $prefixA:expr, $prefixB:expr) => (
-        impl_confidential_commitment!($name, $inner, $prefixA, $prefixB, |x|x);
-    );
-    ($name:ident, $inner:ty, $prefixA:expr, $prefixB:expr, $explicit_fn:expr) => (
-        impl $name {
-            /// Create from commitment.
-            pub fn from_commitment(bytes: &[u8]) -> Result<$name, encode::Error> {
-                if bytes.len() != 33 {
-                    return Err(encode::Error::ParseFailed("commitments must be 33 bytes long"));
-                }
-                let prefix = bytes[0];
-                if prefix != $prefixA && prefix != $prefixB {
-                    return Err(encode::Error::InvalidConfidentialPrefix(prefix));
-                }
-                let mut c = [0; 32];
-                c.copy_from_slice(&bytes[1..]);
-                Ok($name::Confidential(prefix, c))
-            }
-
-            /// Check if the object is null.
-            pub fn is_null(&self) -> bool {
-                match *self {
-                    $name::Null => true,
-                    _ => false,
-                }
-            }
-
-            /// Check if the object is explicit.
-            pub fn is_explicit(&self) -> bool {
-                match *self {
-                    $name::Explicit(_) => true,
-                    _ => false,
-                }
-            }
-
-            /// Check if the object is confidential.
-            pub fn is_confidential(&self) -> bool {
-                match *self {
-                    // Impossible to create an object with invalid prefix.
-                    $name::Explicit(_) => true,
-                    _ => false,
-                }
-            }
-
-            /// Returns the explicit inner value.
-            /// Returns [None] if [is_explicit] returns false.
-            pub fn explicit(&self) -> Option<$inner> {
-                match *self {
-                    $name::Explicit(i) => Some(i),
-                    _ => None,
-                }
-            }
-
-            /// Returns the confidential commitment in case of a confidential value.
-            /// Returns [None] if [is_confidential] returns false.
-            pub fn commitment(&self) -> Option<[u8; 33]> {
-                match *self {
-                    $name::Confidential(p, c) => {
-                        let mut res = [0; 33];
-                        res[0] = p;
-                        res[1..].copy_from_slice(&c[..]);
-                        Some(res)
-                    }
-                    _ => None,
-                }
-            }
-        }
-
-        impl Default for $name {
-            fn default() -> Self {
-                $name::Null
-            }
-        }
-
-        impl Encodable for $name {
-            fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, encode::Error> {
-                match *self {
-                    $name::Null => 0u8.consensus_encode(s),
-                    $name::Explicit(n) => {
-                        1u8.consensus_encode(&mut s)?;
-                        // Apply $explicit_fn to allow `Value` to swap the amount bytes
-                        Ok(1 + $explicit_fn(n).consensus_encode(&mut s)?)
-                    }
-                    $name::Confidential(prefix, bytes) => {
-                        Ok(prefix.consensus_encode(&mut s)? + bytes.consensus_encode(&mut s)?)
-                    }
-                }
-            }
-        }
-
-        impl Decodable for $name {
-            fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<$name, encode::Error> {
-                let prefix = u8::consensus_decode(&mut d)?;
-                match prefix {
-                    0 => Ok($name::Null),
-                    1 => {
-                        // Apply $explicit_fn to allow `Value` to swap the amount bytes
-                        let explicit = $explicit_fn(Decodable::consensus_decode(&mut d)?);
-                        Ok($name::Explicit(explicit))
-                    }
-                    p if p == $prefixA || p == $prefixB => {
-                        let commitment = <[u8; 32]>::consensus_decode(&mut d)?;
-                        Ok($name::Confidential(p, commitment))
-                    }
-                    p => return Err(encode::Error::InvalidConfidentialPrefix(p)),
-                }
-            }
-        }
-
-        #[cfg(feature = "serde")]
-        impl Serialize for $name {
-            fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-                use serde::ser::SerializeSeq;
-
-                let seq_len = if *self == $name::Null { 1 } else { 2 };
-                let mut seq = s.serialize_seq(Some(seq_len))?;
-
-                match *self {
-                    $name::Null => seq.serialize_element(&0u8)?,
-                    $name::Explicit(n) => {
-                        seq.serialize_element(&1u8)?;
-                        // Apply $explicit_fn to allow `Value` to swap the amount bytes
-                        seq.serialize_element(&$explicit_fn(n))?;
-                    }
-                    $name::Confidential(prefix, bytes) => {
-                        seq.serialize_element(&prefix)?;
-                        seq.serialize_element(&bytes)?;
-                    }
-                }
-                seq.end()
-            }
-        }
-
-        #[cfg(feature = "serde")]
-        impl<'de> Deserialize<'de> for $name {
-            fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-                use serde::de::{Error, Visitor, SeqAccess};
-                struct CommitVisitor;
-
-                impl <'de> Visitor<'de> for CommitVisitor {
-                    type Value = $name;
-
-                    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                        f.write_str("a committed value")
-                    }
-
-                    fn visit_seq<A: SeqAccess<'de>>(self, mut access: A) -> Result<Self::Value, A::Error> {
-                        let prefix: u8 = if let Some(x) = access.next_element()? {
-                            x
-                        } else {
-                            return Err(A::Error::custom("missing prefix"));
-                        };
-
-                        match prefix {
-                            0 => Ok($name::Null),
-                            1 => {
-                                // Apply $explicit_fn to allow `Value` to swap the amount bytes
-                                match access.next_element()? {
-                                    Some(x) => Ok($name::Explicit($explicit_fn(x))),
-                                    None => Err(A::Error::custom("missing commitment")),
-                                }
-                            }
-                            p if p == $prefixA || p == $prefixB => {
-                                match access.next_element()? {
-                                    Some(y) => Ok($name::Confidential(p, y)),
-                                    None => Err(A::Error::custom("missing commitment")),
-                                }
-                            }
-                            p => return Err(A::Error::custom(format!(
-                                "invalid commitment, invalid prefix: 0x{:02x}", p
-                            ))),
-                        }
-                    }
-                }
-
-                d.deserialize_seq(CommitVisitor)
-            }
-        }
-    );
-}
-
 /// A CT commitment to an amount
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Value {
     /// No value
     Null,
     /// Value is explicitly encoded
     Explicit(u64),
-    // Split commitments into a 1-byte prefix and 32-byte commitment, because
-    // they're easy enough to separate and Rust stdlib treats 32-byte arrays
-    // much much better than 33-byte arrays.
     /// Value is committed
-    Confidential(u8, [u8; 32]),
+    Confidential(PedersenCommitment),
 }
-impl_confidential_commitment!(Value, u64, 0x08, 0x09, u64::swap_bytes);
 
 impl Value {
     /// Serialized length, in bytes
@@ -233,6 +46,59 @@ impl Value {
             Value::Confidential(..) => 33,
         }
     }
+
+    /// Create from commitment.
+    pub fn from_commitment(bytes: &[u8]) -> Result<Self, encode::Error> {
+        Ok(Value::Confidential(PedersenCommitment::from_slice(bytes)?))
+    }
+
+    /// Check if the object is null.
+    pub fn is_null(&self) -> bool {
+        match self {
+            Value::Null => true,
+            _ => false
+        }
+    }
+
+    /// Check if the object is explicit.
+    pub fn is_explicit(&self) -> bool {
+        match self {
+            Value::Explicit(_) => true,
+            _ => false
+        }
+    }
+
+    /// Check if the object is confidential.
+    pub fn is_confidential(&self) -> bool {
+        match self {
+            Value::Confidential(_) => true,
+            _ => false
+        }
+    }
+
+    /// Returns the explicit inner value.
+    /// Returns [None] if [is_explicit] returns false.
+    pub fn explicit(&self) -> Option<u64> {
+        match *self {
+            Value::Explicit(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    /// Returns the confidential commitment in case of a confidential value.
+    /// Returns [None] if [is_confidential] returns false.
+    pub fn commitment(&self) -> Option<PedersenCommitment> {
+        match *self {
+            Value::Confidential(i) => Some(i),
+            _ => None,
+        }
+    }
+}
+
+impl From<PedersenCommitment> for Value {
+    fn from(from: PedersenCommitment) -> Self {
+        Value::Confidential(from)
+    }
 }
 
 impl fmt::Display for Value {
@@ -240,28 +106,151 @@ impl fmt::Display for Value {
         match *self {
             Value::Null => f.write_str("null"),
             Value::Explicit(n) => write!(f, "{}", n),
-            Value::Confidential(prefix, bytes) => {
-                write!(f, "{:02x}", prefix)?;
-                for b in bytes.iter() {
-                    write!(f, "{:02x}", b)?;
-                }
-                Ok(())
-            }
+            Value::Confidential(commitment) => write!(f, "{:02x}", commitment),
         }
     }
 }
 
+impl Default for Value {
+    fn default() -> Self {
+        Value::Null
+    }
+}
+
+impl Encodable for Value {
+    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, encode::Error> {
+        match *self {
+            Value::Null => 0u8.consensus_encode(s),
+            Value::Explicit(n) => {
+                1u8.consensus_encode(&mut s)?;
+                Ok(1 + u64::swap_bytes(n).consensus_encode(&mut s)?)
+            }
+            Value::Confidential(commitment) => commitment.consensus_encode(&mut s),
+        }
+    }
+}
+
+impl Encodable for PedersenCommitment {
+    fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, encode::Error> {
+        e.write_all(&self.serialize())?;
+        Ok(33)
+    }
+}
+
+impl Decodable for Value {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Value, encode::Error> {
+        let prefix = {
+            let buffer = d.fill_buf()?;
+
+            if buffer.is_empty() {
+                return Err(encode::Error::UnexpectedEOF);
+            }
+
+            buffer[0]
+        };
+
+        match prefix {
+            0 => {
+                // consume null value prefix
+                d.consume(1);
+                Ok(Value::Null)
+            }
+            1 => {
+                // ignore prefix when decoding an explicit value
+                d.consume(1);
+                let explicit = u64::swap_bytes(Decodable::consensus_decode(&mut d)?);
+                Ok(Value::Explicit(explicit))
+            }
+            p if p == 0x08 || p == 0x09 => {
+                let commitment = Decodable::consensus_decode(&mut d)?;
+                Ok(Value::Confidential(commitment))
+            }
+            p => Err(encode::Error::InvalidConfidentialPrefix(p)),
+        }
+    }
+}
+
+impl Decodable for PedersenCommitment {
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, encode::Error> {
+        let bytes = <[u8; 33]>::consensus_decode(d)?;
+        Ok(PedersenCommitment::from_slice(&bytes)?)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Value {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+
+        let seq_len = match *self {
+            Value::Null => 1,
+            Value::Explicit(_) | Value::Confidential(_) => 2
+        };
+        let mut seq = s.serialize_seq(Some(seq_len))?;
+
+        match *self {
+            Value::Null => seq.serialize_element(&0u8)?,
+            Value::Explicit(n) => {
+                seq.serialize_element(&1u8)?;
+                seq.serialize_element(&u64::swap_bytes(n))?;
+            }
+            Value::Confidential(commitment) => {
+                seq.serialize_element(&2u8)?;
+                seq.serialize_element(&commitment)?;
+            }
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Value {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::{Error, SeqAccess, Visitor};
+        struct CommitVisitor;
+
+        impl<'de> Visitor<'de> for CommitVisitor {
+            type Value = Value;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a committed value")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut access: A) -> Result<Self::Value, A::Error> {
+                let prefix = access.next_element()?;
+                match prefix {
+                    Some(0) => Ok(Value::Null),
+                    Some(1) => {
+                        match access.next_element()? {
+                            Some(x) => Ok(Value::Explicit(u64::swap_bytes(x))),
+                            None => Err(A::Error::custom("missing explicit value")),
+                        }
+                    }
+                    Some(2) => {
+                        match access.next_element()? {
+                            Some(x) => Ok(Value::Confidential(x)),
+                            None => Err(A::Error::custom("missing pedersen commitment")),
+                        }
+                    }
+                    _ => Err(A::Error::custom("wrong or missing prefix")),
+                }
+            }
+        }
+
+        d.deserialize_seq(CommitVisitor)
+    }
+}
+
 /// A CT commitment to an asset
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Asset {
     /// No value
     Null,
     /// Asset entropy is explicitly encoded
     Explicit(AssetId),
     /// Asset is committed
-    Confidential(u8, [u8; 32]),
+    Confidential(Generator),
 }
-impl_confidential_commitment!(Asset, AssetId, 0x0a, 0x0b);
 
 impl Asset {
     /// Serialized length, in bytes
@@ -272,6 +261,59 @@ impl Asset {
             Asset::Confidential(..) => 33,
         }
     }
+
+    /// Create from commitment.
+    pub fn from_commitment(bytes: &[u8]) -> Result<Self, encode::Error> {
+        Ok(Asset::Confidential(Generator::from_slice(bytes)?))
+    }
+
+    /// Check if the object is null.
+    pub fn is_null(&self) -> bool {
+        match *self {
+            Asset::Null => true,
+            _ => false
+        }
+    }
+
+    /// Check if the object is explicit.
+    pub fn is_explicit(&self) -> bool {
+        match *self {
+            Asset::Explicit(_) => true,
+            _ => false
+        }
+    }
+
+    /// Check if the object is confidential.
+    pub fn is_confidential(&self) -> bool {
+        match *self {
+            Asset::Confidential(_) => true,
+            _ => false
+        }
+    }
+
+    /// Returns the explicit inner value.
+    /// Returns [None] if [is_explicit] returns false.
+    pub fn explicit(&self) -> Option<AssetId> {
+        match *self {
+            Asset::Explicit(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    /// Returns the confidential commitment in case of a confidential value.
+    /// Returns [None] if [is_confidential] returns false.
+    pub fn commitment(&self) -> Option<Generator> {
+        match *self {
+            Asset::Confidential(i) => Some(i),
+            _ => None,
+        }
+    }
+}
+
+impl From<Generator> for Asset {
+    fn from(from: Generator) -> Self {
+        Asset::Confidential(from)
+    }
 }
 
 impl fmt::Display for Asset {
@@ -279,14 +321,139 @@ impl fmt::Display for Asset {
         match *self {
             Asset::Null => f.write_str("null"),
             Asset::Explicit(n) => write!(f, "{}", n),
-            Asset::Confidential(prefix, bytes) => {
-                write!(f, "{:02x}", prefix)?;
-                for b in bytes.iter() {
-                    write!(f, "{:02x}", b)?;
-                }
-                Ok(())
+            Asset::Confidential(generator) => write!(f, "{:02x}", generator),
+        }
+    }
+}
+
+impl Default for Asset {
+    fn default() -> Self {
+        Asset::Null
+    }
+}
+
+impl Encodable for Asset {
+    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, encode::Error> {
+        match *self {
+            Asset::Null => 0u8.consensus_encode(s),
+            Asset::Explicit(n) => {
+                1u8.consensus_encode(&mut s)?;
+                Ok(1 + n.consensus_encode(&mut s)?)
+            }
+            Asset::Confidential(generator) => generator.consensus_encode(&mut s)
+        }
+    }
+}
+
+impl Encodable for Generator {
+    fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, encode::Error> {
+        e.write_all(&self.serialize())?;
+        Ok(33)
+    }
+}
+
+impl Decodable for Asset {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Self, encode::Error> {
+        let prefix = {
+            let buffer = d.fill_buf()?;
+
+            if buffer.is_empty() {
+                return Err(encode::Error::UnexpectedEOF);
+            }
+
+            buffer[0]
+        };
+
+        match prefix {
+            0 => {
+                // consume null value prefix
+                d.consume(1);
+                Ok(Asset::Null)
+            }
+            1 => {
+                // ignore prefix when decoding an explicit asset
+                d.consume(1);
+                let explicit = Decodable::consensus_decode(&mut d)?;
+                Ok(Asset::Explicit(explicit))
+            }
+            p if p == 0x0a || p == 0x0b => {
+                let generator = Decodable::consensus_decode(&mut d)?;
+                Ok(Asset::Confidential(generator))
+            }
+            p => Err(encode::Error::InvalidConfidentialPrefix(p)),
+        }
+    }
+}
+
+impl Decodable for Generator {
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, encode::Error> {
+        let bytes = <[u8; 33]>::consensus_decode(d)?;
+        Ok(Generator::from_slice(&bytes)?)
+    }
+}
+
+
+#[cfg(feature = "serde")]
+impl Serialize for Asset {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+
+        let seq_len = match *self {
+            Asset::Null => 1,
+            Asset::Explicit(_) | Asset::Confidential(_) => 2
+        };
+        let mut seq = s.serialize_seq(Some(seq_len))?;
+
+        match *self {
+            Asset::Null => seq.serialize_element(&0u8)?,
+            Asset::Explicit(n) => {
+                seq.serialize_element(&1u8)?;
+                seq.serialize_element(&n)?;
+            }
+            Asset::Confidential(commitment) => {
+                seq.serialize_element(&2u8)?;
+                seq.serialize_element(&commitment)?;
             }
         }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Asset {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::{Error, SeqAccess, Visitor};
+        struct CommitVisitor;
+
+        impl<'de> Visitor<'de> for CommitVisitor {
+            type Value = Asset;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a committed value")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut access: A) -> Result<Asset, A::Error> {
+                let prefix = access.next_element()?;
+                match prefix {
+                    Some(0) => Ok(Asset::Null),
+                    Some(1) => {
+                        match access.next_element()? {
+                            Some(x) => Ok(Asset::Explicit(x)),
+                            None => Err(A::Error::custom("missing explicit asset")),
+                        }
+                    }
+                    Some(2) => {
+                        match access.next_element()? {
+                            Some(x) => Ok(Asset::Confidential(x)),
+                            None => Err(A::Error::custom("missing generator")),
+                        }
+                    }
+                    _ => Err(A::Error::custom("wrong or missing prefix")),
+                }
+            }
+        }
+
+        d.deserialize_seq(CommitVisitor)
     }
 }
 
@@ -300,9 +467,8 @@ pub enum Nonce {
     /// that implements all the traits we need.
     Explicit([u8; 32]),
     /// Nonce is committed
-    Confidential(u8, [u8; 32]),
+    Confidential(PublicKey),
 }
-impl_confidential_commitment!(Nonce, [u8; 32], 0x02, 0x03);
 
 impl Nonce {
     /// Serialized length, in bytes
@@ -312,6 +478,61 @@ impl Nonce {
             Nonce::Explicit(..) => 33,
             Nonce::Confidential(..) => 33,
         }
+    }
+
+    /// Create from commitment.
+    pub fn from_commitment(bytes: &[u8]) -> Result<Self, encode::Error> {
+        Ok(Nonce::Confidential(
+            PublicKey::from_slice(bytes).map_err(secp256k1_zkp::Error::Upstream)?,
+        ))
+    }
+
+    /// Check if the object is null.
+    pub fn is_null(&self) -> bool {
+        match *self {
+            Nonce::Null => true,
+            _ => false
+        }
+    }
+
+    /// Check if the object is explicit.
+    pub fn is_explicit(&self) -> bool {
+        match *self {
+            Nonce::Explicit(_) => true,
+            _ => false
+        }
+    }
+
+    /// Check if the object is confidential.
+    pub fn is_confidential(&self) -> bool {
+        match *self {
+            Nonce::Confidential(_) => true,
+            _ => false
+        }
+    }
+
+    /// Returns the explicit inner value.
+    /// Returns [None] if [is_explicit] returns false.
+    pub fn explicit(&self) -> Option<[u8; 32]> {
+        match *self {
+            Nonce::Explicit(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    /// Returns the confidential commitment in case of a confidential value.
+    /// Returns [None] if [is_confidential] returns false.
+    pub fn commitment(&self) -> Option<PublicKey> {
+        match *self {
+            Nonce::Confidential(i) => Some(i),
+            _ => None,
+        }
+    }
+}
+
+impl From<PublicKey> for Nonce {
+    fn from(from: PublicKey) -> Self {
+        Nonce::Confidential(from)
     }
 }
 
@@ -324,29 +545,157 @@ impl fmt::Display for Nonce {
                     write!(f, "{:02x}", b)?;
                 }
                 Ok(())
-            },
-            Nonce::Confidential(prefix, bytes) => {
-                write!(f, "{:02x}", prefix)?;
-                for b in bytes.iter() {
-                    write!(f, "{:02x}", b)?;
-                }
-                Ok(())
+            }
+            Nonce::Confidential(pk) => write!(f, "{:02x}", pk),
+        }
+    }
+}
+
+impl Default for Nonce {
+    fn default() -> Self {
+        Nonce::Null
+    }
+}
+
+impl Encodable for Nonce {
+    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, encode::Error> {
+        match *self {
+            Nonce::Null => 0u8.consensus_encode(s),
+            Nonce::Explicit(n) => {
+                1u8.consensus_encode(&mut s)?;
+                Ok(1 + n.consensus_encode(&mut s)?)
+            }
+            Nonce::Confidential(commitment) => commitment.consensus_encode(&mut s),
+        }
+    }
+}
+
+impl Encodable for PublicKey {
+    fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, encode::Error> {
+        e.write_all(&self.serialize())?;
+        Ok(33)
+    }
+}
+
+impl Decodable for Nonce {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Self, encode::Error> {
+        let prefix = {
+            let buffer = d.fill_buf()?;
+
+            if buffer.is_empty() {
+                return Err(encode::Error::UnexpectedEOF);
+            }
+
+            buffer[0]
+        };
+
+        match prefix {
+            0 => {
+                // consume null value prefix
+                d.consume(1);
+                Ok(Nonce::Null)
+            }
+            1 => {
+                // ignore prefix when decoding an explicit asset
+                d.consume(1);
+                let explicit = Decodable::consensus_decode(&mut d)?;
+                Ok(Nonce::Explicit(explicit))
+            }
+            p if p == 0x02 || p == 0x03 => {
+                let pk = Decodable::consensus_decode(&mut d)?;
+                Ok(Nonce::Confidential(pk))
+            }
+            p => Err(encode::Error::InvalidConfidentialPrefix(p)),
+        }
+    }
+}
+
+impl Decodable for PublicKey {
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, encode::Error> {
+        let bytes = <[u8; 33]>::consensus_decode(d)?;
+        Ok(PublicKey::from_slice(&bytes)?)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Nonce {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+
+        let seq_len = match *self {
+            Nonce::Null => 1,
+            Nonce::Explicit(_) | Nonce::Confidential(_) => 2
+        };
+        let mut seq = s.serialize_seq(Some(seq_len))?;
+
+        match *self {
+            Nonce::Null => seq.serialize_element(&0u8)?,
+            Nonce::Explicit(n) => {
+                seq.serialize_element(&1u8)?;
+                seq.serialize_element(&n)?;
+            }
+            Nonce::Confidential(commitment) => {
+                seq.serialize_element(&2u8)?;
+                seq.serialize_element(&commitment)?;
             }
         }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Nonce {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::{Error, SeqAccess, Visitor};
+        struct CommitVisitor;
+
+        impl<'de> Visitor<'de> for CommitVisitor {
+            type Value = Nonce;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a committed value")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut access: A) -> Result<Nonce, A::Error> {
+                let prefix = access.next_element()?;
+                match prefix {
+                    Some(0) => Ok(Nonce::Null),
+                    Some(1) => {
+                        match access.next_element()? {
+                            Some(x) => Ok(Nonce::Explicit(x)),
+                            None => Err(A::Error::custom("missing explicit nonce")),
+                        }
+                    }
+                    Some(2) => {
+                        match access.next_element()? {
+                            Some(x) => Ok(Nonce::Confidential(x)),
+                            None => Err(A::Error::custom("missing nonce")),
+                        }
+                    }
+                    _ => Err(A::Error::custom("wrong or missing prefix"))
+                }
+            }
+        }
+
+        d.deserialize_seq(CommitVisitor)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::hashes::sha256;
     use super::*;
+    use bitcoin::hashes::sha256;
 
     #[test]
     fn encode_length() {
         let vals = [
             Value::Null,
             Value::Explicit(1000),
-            Value::Confidential(0x08, [1; 32]),
+            Value::from_commitment(&[
+                0x08, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1,
+            ])
+            .unwrap(),
         ];
         for v in &vals[..] {
             let mut x = vec![];
@@ -357,7 +706,11 @@ mod tests {
         let nonces = [
             Nonce::Null,
             Nonce::Explicit([0; 32]),
-            Nonce::Confidential(0x02, [1; 32]),
+            Nonce::from_commitment(&[
+                0x02, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1,
+            ])
+            .unwrap(),
         ];
         for v in &nonces[..] {
             let mut x = vec![];
@@ -368,7 +721,11 @@ mod tests {
         let assets = [
             Asset::Null,
             Asset::Explicit(AssetId::from_inner(sha256::Midstate::from_inner([0; 32]))),
-            Asset::Confidential(0x0a, [1; 32]),
+            Asset::from_commitment(&[
+                0x0a, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1,
+            ])
+            .unwrap(),
         ];
         for v in &assets[..] {
             let mut x = vec![];
@@ -379,20 +736,35 @@ mod tests {
 
     #[test]
     fn commitments() {
-        let x = Value::Confidential(0x08, [1; 32]);
-        let mut commitment = x.commitment().unwrap();
+        let x = Value::from_commitment(&[
+            0x08, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1,
+        ])
+        .unwrap();
+        let commitment = x.commitment().unwrap();
+        let mut commitment = commitment.serialize();
         assert_eq!(x, Value::from_commitment(&commitment[..]).unwrap());
         commitment[0] = 42;
         assert!(Value::from_commitment(&commitment[..]).is_err());
 
-        let x = Asset::Confidential(0x0a, [1; 32]);
-        let mut commitment = x.commitment().unwrap();
+        let x = Asset::from_commitment(&[
+            0x0a, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1,
+        ])
+        .unwrap();
+        let commitment = x.commitment().unwrap();
+        let mut commitment = commitment.serialize();
         assert_eq!(x, Asset::from_commitment(&commitment[..]).unwrap());
         commitment[0] = 42;
         assert!(Asset::from_commitment(&commitment[..]).is_err());
 
-        let x = Nonce::Confidential(0x02, [1; 32]);
-        let mut commitment = x.commitment().unwrap();
+        let x = Nonce::from_commitment(&[
+            0x02, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1,
+        ])
+        .unwrap();
+        let commitment = x.commitment().unwrap();
+        let mut commitment = commitment.serialize();
         assert_eq!(x, Nonce::from_commitment(&commitment[..]).unwrap());
         commitment[0] = 42;
         assert!(Nonce::from_commitment(&commitment[..]).is_err());
@@ -401,7 +773,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn value_serde() {
-        use serde_test::{assert_tokens, Token};
+        use serde_test::{assert_tokens, Configure, Token};
 
         let value = Value::Explicit(100_000_000);
         assert_tokens(
@@ -419,22 +791,29 @@ mod tests {
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         ]).unwrap();
-
         assert_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Seq { len: Some(2) },
-                Token::U8(8),
-                Token::Tuple { len: 32 },
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::TupleEnd,
+                Token::U8(2),
+                Token::Str(
+                    "080101010101010101010101010101010101010101010101010101010101010101"
+                ),
+                Token::SeqEnd
+            ]
+        );
+        assert_tokens(
+            &value.compact(),
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(2),
+                Token::Bytes(
+                    &[
+                        8,
+                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+                    ]
+                ),
                 Token::SeqEnd
             ]
         );
@@ -492,20 +871,28 @@ mod tests {
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         ]).unwrap();
         assert_tokens(
-            &asset,
+            &asset.readable(),
             &[
                 Token::Seq { len: Some(2) },
-                Token::U8(10),
-                Token::Tuple { len: 32 },
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::TupleEnd,
+                Token::U8(2),
+                Token::Str(
+                    "0a0101010101010101010101010101010101010101010101010101010101010101"
+                ),
+                Token::SeqEnd
+            ]
+        );
+        assert_tokens(
+            &asset.compact(),
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(2),
+                Token::Bytes(
+                    &[
+                        10,
+                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+                    ]
+                ),
                 Token::SeqEnd
             ]
         );
@@ -524,7 +911,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn nonce_serde() {
-        use serde_test::{assert_tokens, Token};
+        use serde_test::{assert_tokens, Configure, Token};
 
         let nonce = Nonce::Explicit([
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -555,20 +942,28 @@ mod tests {
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         ]).unwrap();
         assert_tokens(
-            &nonce,
+            &nonce.readable(),
             &[
                 Token::Seq { len: Some(2) },
                 Token::U8(2),
-                Token::Tuple { len: 32 },
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
-                Token::TupleEnd,
+                Token::Str(
+                    "020101010101010101010101010101010101010101010101010101010101010101"
+                ),
+                Token::SeqEnd
+            ]
+        );
+        assert_tokens(
+            &nonce.compact(),
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(2),
+                Token::Bytes(
+                    &[
+                        2,
+                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+                    ]
+                ),
                 Token::SeqEnd
             ]
         );

--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -397,5 +397,190 @@ mod tests {
         commitment[0] = 42;
         assert!(Nonce::from_commitment(&commitment[..]).is_err());
     }
-}
 
+    #[cfg(feature = "serde")]
+    #[test]
+    fn value_serde() {
+        use serde_test::{assert_tokens, Token};
+
+        let value = Value::Explicit(100_000_000);
+        assert_tokens(
+            &value,
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(1),
+                Token::U64(63601271583539200),
+                Token::SeqEnd
+            ]
+        );
+
+        let value = Value::from_commitment(&[
+            0x08,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        ]).unwrap();
+
+        assert_tokens(
+            &value,
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(8),
+                Token::Tuple { len: 32 },
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::TupleEnd,
+                Token::SeqEnd
+            ]
+        );
+
+        let value = Value::Null;
+        assert_tokens(
+            &value,
+            &[
+                Token::Seq { len: Some(1) },
+                Token::U8(0),
+                Token::SeqEnd
+            ]
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn asset_serde() {
+        use bitcoin::hashes::hex::FromHex;
+        use serde_test::{assert_tokens, Configure, Token};
+
+        let asset_id = AssetId::from_hex(
+            "630ed6f9b176af03c0cd3f8aa430f9e7b4d988cf2d0b2f204322488f03b00bf8"
+        ).unwrap();
+        let asset = Asset::Explicit(asset_id);
+        assert_tokens(
+            &asset.readable(),
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(1),
+                Token::Str(
+                    "630ed6f9b176af03c0cd3f8aa430f9e7b4d988cf2d0b2f204322488f03b00bf8"
+                ),
+                Token::SeqEnd
+            ]
+        );
+        assert_tokens(
+            &asset.compact(),
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(1),
+                Token::Bytes(
+                    &[
+                        248, 11, 176, 3, 143, 72, 34, 67, 32, 47, 11, 45, 207, 136, 217, 180,
+                        231, 249, 48, 164, 138, 63, 205, 192, 3, 175, 118, 177, 249, 214, 14, 99
+                    ]
+                ),
+                Token::SeqEnd
+            ]
+        );
+
+        let asset = Asset::from_commitment(&[
+            0x0a,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        ]).unwrap();
+        assert_tokens(
+            &asset,
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(10),
+                Token::Tuple { len: 32 },
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::TupleEnd,
+                Token::SeqEnd
+            ]
+        );
+
+        let asset = Asset::Null;
+        assert_tokens(
+            &asset,
+            &[
+                Token::Seq { len: Some(1) },
+                Token::U8(0),
+                Token::SeqEnd
+            ]
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn nonce_serde() {
+        use serde_test::{assert_tokens, Token};
+
+        let nonce = Nonce::Explicit([
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        ]);
+        assert_tokens(
+            &nonce,
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(1),
+                Token::Tuple { len: 32 },
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::TupleEnd,
+                Token::SeqEnd
+            ]
+        );
+
+        let nonce = Nonce::from_commitment(&[
+            0x02,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        ]).unwrap();
+        assert_tokens(
+            &nonce,
+            &[
+                Token::Seq { len: Some(2) },
+                Token::U8(2),
+                Token::Tuple { len: 32 },
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::U8(1), Token::U8(1), Token::U8(1), Token::U8(1),
+                Token::TupleEnd,
+                Token::SeqEnd
+            ]
+        );
+
+        let nonce = Nonce::Null;
+        assert_tokens(
+            &nonce,
+            &[
+                Token::Seq { len: Some(1) },
+                Token::U8(0),
+                Token::SeqEnd
+            ]
+        );
+    }
+}

--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -119,7 +119,7 @@ macro_rules! impl_confidential_commitment {
         }
 
         impl Decodable for $name {
-            fn consensus_decode<D: io::Read>(mut d: D) -> Result<$name, encode::Error> {
+            fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<$name, encode::Error> {
                 let prefix = u8::consensus_decode(&mut d)?;
                 match prefix {
                     0 => Ok($name::Null),

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -434,7 +434,7 @@ impl Encodable for Params {
 }
 
 impl Decodable for Params {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Self, encode::Error> {
         let ser_type: u8 = Decodable::consensus_decode(&mut d)?;
         match ser_type {
             0 => Ok(Params::Null),

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -149,7 +149,7 @@ impl Params {
         }
 
         match *self {
-            Params::Null => return sha256::Midstate::from_inner([0u8; 32]),
+            Params::Null => sha256::Midstate::from_inner([0u8; 32]),
             Params::Compact { ref elided_root, .. } => *elided_root,
             Params::Full { ref fedpeg_program, ref fedpegscript, ref extension_space, .. } => {
                 let leaves = [
@@ -200,14 +200,14 @@ impl Params {
             Params::Null => None,
             Params::Compact { signblockscript, signblock_witness_limit, elided_root } => {
                 Some(Params::Compact {
-                    signblockscript: signblockscript,
+                    signblockscript,
                     signblock_witness_limit,
-                    elided_root: elided_root,
+                    elided_root,
                 })
             }
             Params::Full { signblockscript, signblock_witness_limit, ..} => {
                 Some(Params::Compact {
-                    signblockscript: signblockscript,
+                    signblockscript,
                     signblock_witness_limit,
                     elided_root: extra_root.unwrap(),
                 })
@@ -350,7 +350,7 @@ impl<'de> Deserialize<'de> for Params {
             }
         }
 
-        static FIELDS: &'static [&'static str] = &[
+        static FIELDS: &[&str] = &[
             "signblockscript",
             "signblock_witness_limit",
             "fedpeg_program",
@@ -510,7 +510,7 @@ mod tests {
         );
 
         let full_entry = Params::Full {
-            signblockscript: signblockscript,
+            signblockscript,
             signblock_witness_limit: signblock_wl,
             fedpeg_program: fp_program,
             fedpegscript: fp_script,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -137,7 +137,7 @@ pub fn serialize_hex<T: Encodable + ?Sized>(data: &T) -> String {
 
 /// Deserialize an object from a vector, will error if said deserialization
 /// doesn't consume the entire vector.
-pub fn deserialize<'a, T: Decodable>(data: &'a [u8]) -> Result<T, Error> {
+pub fn deserialize<T: Decodable>(data: &[u8]) -> Result<T, Error> {
     let (rv, consumed) = deserialize_partial(data)?;
 
     // Fail if data are not consumed entirely.
@@ -150,7 +150,7 @@ pub fn deserialize<'a, T: Decodable>(data: &'a [u8]) -> Result<T, Error> {
 
 /// Deserialize an object from a vector, but will not report an error if said deserialization
 /// doesn't consume the entire vector.
-pub fn deserialize_partial<'a, T: Decodable>(data: &'a [u8]) -> Result<(T, usize), Error> {
+pub fn deserialize_partial<T: Decodable>(data: &[u8]) -> Result<(T, usize), Error> {
     let mut decoder = Cursor::new(data);
     let rv = Decodable::consensus_decode(&mut decoder)?;
     let consumed = decoder.position() as usize;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -94,7 +94,7 @@ pub trait Encodable {
 /// Data which can be encoded in a consensus-consistent way
 pub trait Decodable: Sized {
     /// Decode an object with a well-defined format
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, Error>;
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, Error>;
 }
 
 /// Encode an object into a vector
@@ -139,7 +139,7 @@ impl Encodable for sha256::Midstate {
 }
 
 impl Decodable for sha256::Midstate {
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, Error> {
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, Error> {
         Ok(Self::from_inner(<[u8; 32]>::consensus_decode(d)?))
     }
 }
@@ -154,7 +154,7 @@ macro_rules! impl_upstream {
         }
 
         impl Decodable for $type {
-            fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+            fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Self, Error> {
                 Ok(btcenc::Decodable::consensus_decode(&mut d)?)
             }
         }
@@ -188,7 +188,7 @@ macro_rules! impl_vec {
 
         impl Decodable for Vec<$type> {
             #[inline]
-            fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+            fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Self, Error> {
                 let len = btcenc::VarInt::consensus_decode(&mut d)?.0;
                 let byte_size = (len as usize)
                     .checked_mul(mem::size_of::<$type>())

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -27,7 +27,7 @@ macro_rules! impl_hashencode {
         }
 
         impl $crate::encode::Decodable for $hashtype {
-            fn consensus_decode<D: ::std::io::Read>(d: D) -> Result<Self, $crate::encode::Error> {
+            fn consensus_decode<D: ::std::io::BufRead>(d: D) -> Result<Self, $crate::encode::Error> {
                 use $crate::bitcoin::hashes::Hash;
                 Ok(Self::from_inner(<<$hashtype as $crate::bitcoin::hashes::Hash>::Inner>::consensus_decode(d)?))
             }
@@ -52,4 +52,3 @@ impl_hashencode!(Wtxid);
 impl_hashencode!(SigHash);
 impl_hashencode!(BlockHash);
 impl_hashencode!(TxMerkleNode);
-

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -16,7 +16,10 @@
 //! to avoid mixing data of the same hash format (like SHA256d) but of different meaning
 //! (transaction id, block hash etc).
 
-use bitcoin::hashes::{Hash, sha256, sha256d,  hash160};
+use bitcoin::{
+    hashes::{hash160, sha256, sha256d, Hash},
+    secp256k1::ThirtyTwoByteHash,
+};
 
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {
@@ -52,3 +55,9 @@ impl_hashencode!(Wtxid);
 impl_hashencode!(SigHash);
 impl_hashencode!(BlockHash);
 impl_hashencode!(TxMerkleNode);
+
+impl ThirtyTwoByteHash for SigHash {
+    fn into_32(self) -> [u8; 32] {
+        self.0.into_inner()
+    }
+}

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -117,7 +117,7 @@ macro_rules! serde_struct_impl {
                         )*
 
                         let ret = $name {
-                            $($fe: $fe),*
+                            $($fe),*
                         };
 
                         Ok(ret)
@@ -262,7 +262,7 @@ macro_rules! serde_struct_human_string_impl {
                             )*
 
                             let ret = $name {
-                                $($fe: $fe),*
+                                $($fe),*
                             };
 
                             Ok(ret)
@@ -298,7 +298,7 @@ macro_rules! serde_struct_human_string_impl {
                             )*
 
                             let ret = $name {
-                                $($fe: $fe),*
+                                $($fe),*
                             };
 
                             Ok(ret)

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -25,7 +25,7 @@ macro_rules! impl_consensus_encoding {
 
         impl $crate::encode::Decodable for $thing {
             #[inline]
-            fn consensus_decode<D: $crate::std::io::Read>(mut d: D) -> Result<$thing, $crate::encode::Error> {
+            fn consensus_decode<D: $crate::std::io::BufRead>(mut d: D) -> Result<$thing, $crate::encode::Error> {
                 Ok($thing {
                     $( $field: $crate::encode::Decodable::consensus_decode(&mut d)?, )+
                 })
@@ -388,4 +388,3 @@ macro_rules! hex_script(
         ::Script::from(v)
     })
 );
-

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -147,10 +147,10 @@ impl ::std::fmt::LowerHex for AssetId {
 }
 
 impl FromStr for AssetId {
-	type Err = hex::Error;
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		hex::FromHex::from_hex(s)
-	}
+    type Err = hex::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        hex::FromHex::from_hex(s)
+    }
 }
 
 impl Encodable for AssetId {
@@ -160,7 +160,7 @@ impl Encodable for AssetId {
 }
 
 impl Decodable for AssetId {
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, encode::Error> {
         Ok(Self::from_inner(sha256::Midstate::consensus_decode(d)?))
     }
 }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -21,6 +21,7 @@ use bitcoin::hashes::{self, hex, sha256, sha256d, Hash};
 
 use encode::{self, Encodable, Decodable};
 use fast_merkle_root::fast_merkle_root;
+use secp256k1_zkp::Tag;
 use transaction::OutPoint;
 
 /// The zero hash.
@@ -116,6 +117,10 @@ impl AssetId {
             true => TWO32,
         };
         AssetId(fast_merkle_root(&[entropy.into_inner(), second]))
+    }
+
+    pub(crate) fn into_tag(self) -> Tag {
+        self.0.into_inner().into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ extern crate slip21;
 
 #[cfg(test)] extern crate rand;
 #[cfg(any(test, feature = "serde_json"))] extern crate serde_json;
+#[cfg(all(test, feature = "serde"))] extern crate serde_test;
 
 #[macro_use] mod internal_macros;
 pub mod address;
@@ -64,4 +65,3 @@ pub use fast_merkle_root::fast_merkle_root;
 pub use hash_types::*;
 pub use issuance::{AssetId, ContractHash};
 pub use script::Script;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ mod endian;
 pub use bitcoin::{bech32, hashes, secp256k1};
 // export everything at the top level so it can be used as `elements::Transaction` etc.
 pub use address::{Address, AddressParams, AddressError};
-pub use transaction::{OutPoint, PeginData, PegoutData, SigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};
+pub use transaction::{OutPoint, PeginData, PegoutData, SigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance, ConfidentialTxOutError};
 pub use block::{BlockHeader, Block};
 pub use block::ExtData as BlockExtData;
 pub use ::bitcoin::consensus::encode::VarInt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,12 @@ pub extern crate bitcoin;
 #[macro_use]
 extern crate bitcoin_hashes as just_imported_for_the_macros;
 extern crate slip21;
+extern crate secp256k1_zkp;
 #[cfg(feature = "serde")] extern crate serde;
+#[cfg(all(test, feature = "serde"))] extern crate serde_test;
 
 #[cfg(test)] extern crate rand;
 #[cfg(any(test, feature = "serde_json"))] extern crate serde_json;
-#[cfg(all(test, feature = "serde"))] extern crate serde_test;
 
 #[macro_use] mod internal_macros;
 pub mod address;

--- a/src/script.rs
+++ b/src/script.rs
@@ -843,7 +843,7 @@ impl Encodable for Script {
 
 impl Decodable for Script {
     #[inline]
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, encode::Error> {
         Ok(Script(Decodable::consensus_decode(d)?))
     }
 }
@@ -1147,7 +1147,7 @@ mod test {
         assert_eq!(v_nonmin_alt.unwrap(), slop_v_nonmin_alt.unwrap());
     }
 
-	#[test]
+        #[test]
     fn script_ord() {
         let script_1 = Builder::new().push_slice(&[1,2,3,4]).into_script();
         let script_2 = Builder::new().push_int(10).into_script();
@@ -1166,4 +1166,3 @@ mod test {
         assert!(script_2 > script_1);
     }
 }
-

--- a/src/script.rs
+++ b/src/script.rs
@@ -252,7 +252,7 @@ impl Script {
         let mut verop = ver.to_u8();
         assert!(verop <= 16, "incorrect witness version provided: {}", verop);
         if verop > 0 {
-            verop = 0x50 + verop;
+            verop += 0x50;
         }
         Builder::new()
             .push_opcode(verop.into())
@@ -549,11 +549,11 @@ impl<'a> Iterator for Instructions<'a> {
                     self.data = &[];  // Kill iterator so that it does not return an infinite stream of errors
                     return Some(Err(Error::EarlyEndOfScript));
                 }
-                if self.enforce_minimal {
-                    if n == 1 && (self.data[1] == 0x81 || (self.data[1] > 0 && self.data[1] <= 16)) {
+                if self.enforce_minimal
+                    && n == 1
+                    && (self.data[1] == 0x81 || (self.data[1] > 0 && self.data[1] <= 16)) {
                         self.data = &[];
                         return Some(Err(Error::NonMinimalPush));
-                    }
                 }
                 let ret = Some(Ok(Instruction::PushBytes(&self.data[1..n+1])));
                 self.data = &self.data[n + 1..];
@@ -881,7 +881,7 @@ mod test {
         script = script.push_int(-10000000); comp.extend([4u8, 128, 150, 152, 128].iter().cloned()); assert_eq!(&script[..], &comp[..]);
 
         // data
-        script = script.push_slice("NRA4VR".as_bytes()); comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned()); assert_eq!(&script[..], &comp[..]);
+        script = script.push_slice(b"NRA4VR"); comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned()); assert_eq!(&script[..], &comp[..]);
 
         // keys
         let keystr = "21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";

--- a/src/script.rs
+++ b/src/script.rs
@@ -1147,7 +1147,7 @@ mod test {
         assert_eq!(v_nonmin_alt.unwrap(), slop_v_nonmin_alt.unwrap());
     }
 
-        #[test]
+    #[test]
     fn script_ord() {
         let script_1 = Builder::new().push_slice(&[1,2,3,4]).into_script();
         let script_2 = Builder::new().push_int(10).into_script();

--- a/src/sighash.rs
+++ b/src/sighash.rs
@@ -50,7 +50,7 @@ impl<R: Deref<Target = Transaction>> SigHashCache<R> {
     /// script_sig and witnesses.
     pub fn new(tx: R) -> Self {
         SigHashCache {
-            tx: tx,
+            tx,
             hash_prevouts: None,
             hash_sequence: None,
             hash_outputs: None,

--- a/src/slip77.rs
+++ b/src/slip77.rs
@@ -9,7 +9,7 @@ use slip21;
 
 use Script;
 
-const SLIP77_DERIVATION: &'static str = "SLIP-0077";
+const SLIP77_DERIVATION: &str = "SLIP-0077";
 
 /// A SLIP-77 master blinding key used to derive shared blinding keys.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -69,7 +69,7 @@ mod tests {
         assert_eq!(master.0, privkey);
 
         let scriptpk_hex = "a914afa92d77cd3541b443771649572db096cf49bf8c87";
-        let scriptpk: Script = Vec::<u8>::from_hex(&scriptpk_hex).unwrap().clone().into();
+        let scriptpk: Script = Vec::<u8>::from_hex(&scriptpk_hex).unwrap().into();
 
         let blindingkey_hex = "02b067c374bb56c54c016fae29218c000ada60f81ef45b4aeebbeb24931bb8bc";
         let blindingkey = SecretKey::from_slice(&Vec::<u8>::from_hex(blindingkey_hex).unwrap()).unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -29,7 +29,7 @@ use script::Instruction;
 use {Script, Txid, Wtxid};
 
 /// Description of an asset issuance in a transaction input
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct AssetIssuance {
     /// Zero for a new asset issuance; otherwise a blinding factor for the input
     pub asset_blinding_nonce: [u8; 32],
@@ -1625,15 +1625,14 @@ mod tests {
             AssetIssuance {
                 asset_blinding_nonce: [0; 32],
                 asset_entropy: [0; 32],
-                amount: confidential::Value::Confidential(
-                    9,
-                    [
-                        0x81, 0x65, 0x4e, 0xb5, 0xcc, 0xd9, 0x92, 0x7b,
-                        0x8b, 0xea, 0x94, 0x99, 0x7d, 0xce, 0x4a, 0xe8,
-                        0x5b, 0x3d, 0x95, 0xa2, 0x07, 0x00, 0x38, 0x4f,
-                        0x0b, 0x8c, 0x1f, 0xe9, 0x95, 0x18, 0x06, 0x38
+                amount: confidential::Value::from_commitment(
+                    &[  0x09, 0x81, 0x65, 0x4e, 0xb5, 0xcc, 0xd9, 0x92,
+                        0x7b, 0x8b, 0xea, 0x94, 0x99, 0x7d, 0xce, 0x4a,
+                        0xe8, 0x5b, 0x3d, 0x95, 0xa2, 0x07, 0x00, 0x38,
+                        0x4f, 0x0b, 0x8c, 0x1f, 0xe9, 0x95, 0x18, 0x06,
+                        0x38
                     ],
-                ),
+                ).unwrap(),
                 inflation_keys: confidential::Value::Null,
             }
         );
@@ -1661,7 +1660,7 @@ mod tests {
 
         // Output with pushes that are e.g. OP_1 are nulldata but not pegouts
         let output: TxOut = hex_deserialize!("\
-            0a2d3634393536d9a2d0aaba3823f442fb24363831fdfd0101010101010101010\
+            0a319c0000000000d3d3d3d3d3d3d3d3d3d3d3d3fdfdfd0101010101010101010\
             1010101010101010101010101010101010101016a01010101fdfdfdfdfdfdfdfd\
             fdfdfdfdfd3ca059fdfdfb6a2000002323232323232323232323232323232\
             3232323232323232321232323010151232323232323232323232323232323\
@@ -1679,7 +1678,7 @@ mod tests {
 
         // Output with just one push and nothing else should be nulldata but not pegout
         let output: TxOut = hex_deserialize!("\
-            0a2d3634393536d9a2d0aaba3823f442fb24363831fdfd0101010101010101010\
+            0a319c0000000000d3d3d3d3d3d3d3d3d3d3d3d3fdfdfd0101010101010101010\
             1010101010101010101010101010101010101016a01010101fdfdfdfdfdfdfdfd\
             fdfdfdfdfd3ca059fdf2226a20000000000000000000000000000000000000000\
             0000000000000000000000000\

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1834,4 +1834,3 @@ mod tests {
         assert_eq!(tx.all_fees()[&fee_asset], 1788);
     }
 }
-

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -57,8 +57,8 @@ impl OutPoint {
     /// Create a new outpoint.
     pub fn new(txid: Txid, vout: u32) -> OutPoint {
         OutPoint {
-            txid: txid,
-            vout: vout,
+            txid,
+            vout,
         }
     }
 }
@@ -85,8 +85,8 @@ impl Decodable for OutPoint {
         let txid = Txid::consensus_decode(&mut d)?;
         let vout = u32::consensus_decode(&mut d)?;
         Ok(OutPoint {
-            txid: txid,
-            vout: vout,
+            txid,
+            vout,
         })
     }
 }
@@ -237,10 +237,10 @@ impl Decodable for TxIn {
         }
         Ok(TxIn {
             previous_output: outp,
-            is_pegin: is_pegin,
-            has_issuance: has_issuance,
-            script_sig: script_sig,
-            sequence: sequence,
+            is_pegin,
+            has_issuance,
+            script_sig,
+            sequence,
             asset_issuance: issuance,
             witness: TxInWitness::default(),
         })
@@ -467,10 +467,10 @@ impl TxOut {
             None
         } else {
             Some(PegoutData {
+                value,
                 asset: self.asset,
-                value: value,
-                genesis_hash: genesis_hash,
-                script_pubkey: script_pubkey,
+                genesis_hash,
+                script_pubkey,
                 extra_data: remainder,
             })
         }
@@ -688,10 +688,10 @@ impl Decodable for Transaction {
 
         match wit_flag {
             0 => Ok(Transaction {
-                version: version,
-                input: input,
-                output: output,
-                lock_time: lock_time,
+                version,
+                lock_time,
+                input,
+                output,
             }),
             1 => {
                 for i in &mut input {
@@ -705,10 +705,10 @@ impl Decodable for Transaction {
                     Err(encode::Error::ParseFailed("witness flag set but no witnesses were given"))
                 } else {
                     Ok(Transaction {
-                        version: version,
-                        input: input,
-                        output: output,
-                        lock_time: lock_time,
+                        version,
+                        lock_time,
+                        input,
+                        output,
                     })
                 }
             }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -15,18 +15,20 @@
 //! # Transactions
 //!
 
-use std::{io, fmt};
+use std::{io, fmt, self};
 use std::collections::HashMap;
 
 use bitcoin::{self, VarInt};
 use bitcoin::hashes::Hash;
 
-use confidential;
+use confidential::{self, AssetBlindingFactor, ValueBlindingFactor, Asset, Nonce, Value};
 use encode::{self, Encodable, Decodable};
 use issuance::AssetId;
 use opcodes;
 use script::Instruction;
 use {Script, Txid, Wtxid};
+use address::Address;
+use secp256k1_zkp::{self, Generator, RangeProof, Secp256k1, Signing, SurjectionProof, rand::{RngCore, CryptoRng}};
 
 /// Description of an asset issuance in a transaction input
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
@@ -373,10 +375,195 @@ impl Decodable for TxOut {
     }
 }
 
+/// Errors encountered when constructing confidential transaction outputs.
+#[derive(Debug, Clone, Copy)]
+pub enum ConfidentialTxOutError {
+    /// The address provided does not have a blinding key.
+    NoBlindingKeyInAddress,
+    /// Error originated in `secp256k1_zkp`.
+    Upstream(secp256k1_zkp::Error),
+}
+
+impl fmt::Display for ConfidentialTxOutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            ConfidentialTxOutError::NoBlindingKeyInAddress => {
+                write!(f, "address does not include a blinding key")
+            }
+            ConfidentialTxOutError::Upstream(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for ConfidentialTxOutError {
+    fn cause(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ConfidentialTxOutError::NoBlindingKeyInAddress => None,
+            ConfidentialTxOutError::Upstream(e) => Some(e),
+        }
+    }
+}
+
+impl From<secp256k1_zkp::Error> for ConfidentialTxOutError {
+    fn from(from: secp256k1_zkp::Error) -> Self {
+        ConfidentialTxOutError::Upstream(from)
+    }
+}
+
 impl TxOut {
+    /// Creates a new confidential output that is **not** the last one in the transaction.
+    pub fn new_not_last_confidential<R, C>(
+        rng: &mut R,
+        secp: &Secp256k1<C>,
+        value: u64,
+        address: Address,
+        asset: AssetId,
+        inputs: &[(
+            AssetId,
+            u64,
+            Generator,
+            AssetBlindingFactor,
+            ValueBlindingFactor,
+        )],
+    ) -> Result<(Self, AssetBlindingFactor, ValueBlindingFactor), ConfidentialTxOutError>
+    where
+        R: RngCore + CryptoRng,
+        C: Signing,
+    {
+        let out_abf = AssetBlindingFactor::new(rng);
+        let out_asset = Asset::new_confidential(secp, asset, out_abf);
+
+        let out_asset_commitment = out_asset.commitment().expect("confidential asset");
+        let out_vbf = ValueBlindingFactor::new(rng);
+        let value_commitment = Value::new_confidential(secp, value, out_asset_commitment, out_vbf);
+
+        let receiver_blinding_pk = &address
+            .blinding_pubkey
+            .ok_or(ConfidentialTxOutError::NoBlindingKeyInAddress)?;
+        let (nonce, shared_secret) = Nonce::new_confidential(rng, secp, receiver_blinding_pk);
+
+        let message = RangeProofMessage { asset, bf: out_abf };
+        let rangeproof = RangeProof::new(
+            secp,
+            1,
+            value_commitment.commitment().expect("confidential value"),
+            value,
+            out_vbf.0,
+            &message.to_bytes(),
+            address.script_pubkey().as_bytes(),
+            shared_secret,
+            0,
+            52,
+            out_asset_commitment,
+        )?;
+
+        let inputs = inputs
+            .iter()
+            .map(|(id, _, asset, abf, _)| (*asset, id.into_tag(), abf.0))
+            .collect::<Vec<_>>();
+
+        let surjection_proof = SurjectionProof::new(
+            secp,
+            rng,
+            asset.into_tag(),
+            out_abf.into_inner(),
+            inputs.as_ref(),
+        )?;
+
+        let txout = TxOut {
+            asset: out_asset,
+            value: value_commitment,
+            nonce,
+            script_pubkey: address.script_pubkey(),
+            witness: TxOutWitness {
+                surjection_proof: surjection_proof.serialize(),
+                rangeproof: rangeproof.serialize(),
+            },
+        };
+
+        Ok((txout, out_abf, out_vbf))
+    }
+
+    /// Creates a new confidential output that IS the last one in the transaction.
+    pub fn new_last_confidential<R, C>(
+        rng: &mut R,
+        secp: &Secp256k1<C>,
+        value: u64,
+        address: Address,
+        asset: AssetId,
+        inputs: &[(
+            AssetId,
+            u64,
+            Generator,
+            AssetBlindingFactor,
+            ValueBlindingFactor,
+        )],
+        outputs: &[(u64, AssetBlindingFactor, ValueBlindingFactor)],
+    ) -> Result<Self, ConfidentialTxOutError>
+    where
+        R: RngCore + CryptoRng,
+        C: Signing,
+    {
+        let (surjection_proof_inputs, value_blind_inputs) = inputs
+            .iter()
+            .map(|(id, value, asset, abf, vbf)| {
+                ((*asset, id.into_tag(), abf.0), (*value, *abf, *vbf))
+            })
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        let out_abf = AssetBlindingFactor::new(rng);
+        let out_asset = Asset::new_confidential(secp, asset, out_abf);
+
+        let out_asset_commitment = out_asset.commitment().expect("confidential asset");
+        let out_vbf =
+            ValueBlindingFactor::last(secp, value, out_abf, &value_blind_inputs, &outputs);
+        let value_commitment = Value::new_confidential(secp, value, out_asset_commitment, out_vbf);
+
+        let receiver_blinding_pk = &address
+            .blinding_pubkey
+            .ok_or(ConfidentialTxOutError::NoBlindingKeyInAddress)?;
+        let (nonce, shared_secret) = Nonce::new_confidential(rng, secp, receiver_blinding_pk);
+
+        let message = RangeProofMessage { asset, bf: out_abf };
+        let rangeproof = RangeProof::new(
+            secp,
+            1,
+            value_commitment.commitment().expect("confidential value"),
+            value,
+            out_vbf.0,
+            &message.to_bytes(),
+            address.script_pubkey().as_bytes(),
+            shared_secret,
+            0,
+            52,
+            out_asset_commitment,
+        )?;
+
+        let surjection_proof = SurjectionProof::new(
+            secp,
+            rng,
+            asset.into_tag(),
+            out_abf.into_inner(),
+            surjection_proof_inputs.as_ref(),
+        )?;
+
+        let txout = TxOut {
+            asset: out_asset,
+            value: value_commitment,
+            nonce,
+            script_pubkey: address.script_pubkey(),
+            witness: TxOutWitness {
+                surjection_proof: surjection_proof.serialize(),
+                rangeproof: rangeproof.serialize(),
+            },
+        };
+
+        Ok(txout)
+    }
+
     /// Create a new fee output.
     pub fn new_fee(amount: u64, asset: AssetId) -> TxOut {
-        TxOut{
+        TxOut {
             asset: confidential::Asset::Explicit(asset),
             value: confidential::Value::Explicit(amount),
             nonce: confidential::Nonce::Null,
@@ -511,6 +698,22 @@ impl TxOut {
                 }
             }
         }
+    }
+}
+
+struct RangeProofMessage {
+    asset: AssetId,
+    bf: AssetBlindingFactor,
+}
+
+impl RangeProofMessage {
+    fn to_bytes(&self) -> [u8; 64] {
+        let mut message = [0u8; 64];
+
+        message[..32].copy_from_slice(self.asset.into_tag().as_ref());
+        message[32..].copy_from_slice(self.bf.into_inner().as_ref());
+
+        message
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -411,6 +411,10 @@ impl From<secp256k1_zkp::Error> for ConfidentialTxOutError {
 }
 
 impl TxOut {
+    const RANGEPROOF_MIN_VALUE: u64 = 1;
+    const RANGEPROOF_EXP_SHIFT: i32 = 0;
+    const RANGEPROOF_MIN_PRIV_BITS: u8 = 52;
+
     /// Creates a new confidential output that is **not** the last one in the transaction.
     pub fn new_not_last_confidential<R, C>(
         rng: &mut R,
@@ -445,15 +449,15 @@ impl TxOut {
         let message = RangeProofMessage { asset, bf: out_abf };
         let rangeproof = RangeProof::new(
             secp,
-            1,
+            Self::RANGEPROOF_MIN_VALUE,
             value_commitment.commitment().expect("confidential value"),
             value,
             out_vbf.0,
             &message.to_bytes(),
             address.script_pubkey().as_bytes(),
             shared_secret,
-            0,
-            52,
+            Self::RANGEPROOF_EXP_SHIFT,
+            Self::RANGEPROOF_MIN_PRIV_BITS,
             out_asset_commitment,
         )?;
 
@@ -527,15 +531,15 @@ impl TxOut {
         let message = RangeProofMessage { asset, bf: out_abf };
         let rangeproof = RangeProof::new(
             secp,
-            1,
+            Self::RANGEPROOF_MIN_VALUE,
             value_commitment.commitment().expect("confidential value"),
             value,
             out_vbf.0,
             &message.to_bytes(),
             address.script_pubkey().as_bytes(),
             shared_secret,
-            0,
-            52,
+            Self::RANGEPROOF_EXP_SHIFT,
+            Self::RANGEPROOF_MIN_PRIV_BITS,
             out_asset_commitment,
         )?;
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -81,7 +81,7 @@ impl Encodable for OutPoint {
 }
 
 impl Decodable for OutPoint {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<OutPoint, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<OutPoint, encode::Error> {
         let txid = Txid::consensus_decode(&mut d)?;
         let vout = u32::consensus_decode(&mut d)?;
         Ok(OutPoint {
@@ -213,7 +213,7 @@ impl Encodable for TxIn {
 }
 
 impl Decodable for TxIn {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<TxIn, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<TxIn, encode::Error> {
         let mut outp = OutPoint::consensus_decode(&mut d)?;
         let script_sig = Script::consensus_decode(&mut d)?;
         let sequence = u32::consensus_decode(&mut d)?;
@@ -362,7 +362,7 @@ impl Encodable for TxOut {
 }
 
 impl Decodable for TxOut {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<TxOut, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<TxOut, encode::Error> {
         Ok(TxOut {
             asset: Decodable::consensus_decode(&mut d)?,
             value: Decodable::consensus_decode(&mut d)?,
@@ -679,7 +679,7 @@ impl Encodable for Transaction {
 }
 
 impl Decodable for Transaction {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Transaction, encode::Error> {
+    fn consensus_decode<D: io::BufRead>(mut d: D) -> Result<Transaction, encode::Error> {
         let version = u32::consensus_decode(&mut d)?;
         let wit_flag = u8::consensus_decode(&mut d)?;
         let mut input = Vec::<TxIn>::consensus_decode(&mut d)?;


### PR DESCRIPTION
This is the part of PR https://github.com/ElementsProject/rust-elements/pull/70 which should be less controversial.

When splitting up that PR and going through @sanket1729's review I noticed that we had broken the serde implementations of `Value`, `Asset` and `Nonce` (and I found [this](https://github.com/ElementsProject/rust-secp256k1-zkp/pull/10) (our) bug in rust-secp256k1-zkp). 

This also made me realise that, by delegating to said library when implementing serde on our types, we had introduced breaking changes. I've documented the original serde implementations with the tests in https://github.com/ElementsProject/rust-elements/commit/1c53b177c3e56c21836fa3f89bb4b4f2da0689ef, to be able to highlight the changes introduced in https://github.com/ElementsProject/rust-elements/commit/516ac0ee35ed5754ab9e8d76f3cfb60643b51a4b. I made some choices there which could be questionable, so please take a look.

---

Once https://github.com/ElementsProject/rust-secp256k1-zkp/pull/10 is merged, we should remove the patch dependency to `luckysori/rust-secp256k1-zkp` in `Cargo.toml`.