### PR TITLE
Release 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elements"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Andrew Poelstra <apoelstra@blockstream.com>"]
 description = "Library with support for de/serialization, parsing and executing on data structures and network messages related to Elements"
 license = "CC0-1.0"


### PR DESCRIPTION
- Change the structure of several Transaction primitives to use
native secp types.
- Support for pset
- Support for transaction blinding and creating confidential
transactions
- Support for unblinding transactions #78 