### PR TITLE
Export blind errors

### DIFF
--- a/src/blind.rs
+++ b/src/blind.rs
@@ -810,7 +810,7 @@ impl Transaction {
     }
 }
 
-/// Errors encountered when constructing confidential transaction outputs.
+/// Errors encountered when blinding transaction outputs.
 #[derive(Debug, Clone, Copy)]
 pub enum BlindError {
     /// The script pubkey does not represent a valid address

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub use bitcoin::{bech32, hashes};
 // export everything at the top level so it can be used as `elements::Transaction` etc.
 pub use address::{Address, AddressParams, AddressError};
 pub use transaction::{OutPoint, PeginData, PegoutData, SigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};
-pub use blind::{ConfidentialTxOutError, TxOutSecrets, TxOutError, VerificationError};
+pub use blind::{ConfidentialTxOutError, TxOutSecrets, TxOutError, VerificationError, BlindError, UnblindError};
 pub use block::{BlockHeader, Block};
 pub use block::ExtData as BlockExtData;
 pub use ::bitcoin::consensus::encode::VarInt;

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -39,9 +39,9 @@ use bitcoin;
 
 use blind::ConfidentialTxOutError;
 
-pub use self::error::Error;
+pub use self::error::{Error, PsetBlindError};
 pub use self::map::{Global, GlobalTxData, Input, Output};
-use self::{error::PsetBlindError, map::Map};
+use self::map::Map;
 
 /// A Partially Signed Transaction.
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
BlindError, UnblindError and PsetBlindError are used by public
functions but are not exported.

However I am not sure those were meant to be exposed.
Perhaps they should have been variants of already exported errors.