### PR TITLE
Remove pub accessor to PSET inputs and outputs 

### DIFF
--- a/examples/pset_blind_coinjoin.rs
+++ b/examples/pset_blind_coinjoin.rs
@@ -197,10 +197,10 @@ fn main() {
     // This tells that person that controls input zero is responsible for
     // blinding outputs 0, 1
     // Output 2 is the fees output
-    pset.outputs[0].blinding_key = Some(dest_btc_blind_pk);
-    pset.outputs[0].blinder_index = Some(0);
-    pset.outputs[1].blinding_key = Some(change_btc_blind_pk);
-    pset.outputs[1].blinder_index = Some(0);
+    pset.outputs_mut()[0].blinding_key = Some(dest_btc_blind_pk);
+    pset.outputs_mut()[0].blinder_index = Some(0);
+    pset.outputs_mut()[1].blinding_key = Some(change_btc_blind_pk);
+    pset.outputs_mut()[1].blinder_index = Some(0);
 
     // pset after adding the information about the bitcoin input from A
     // Pset with 2 input and 3 outputs
@@ -253,10 +253,10 @@ fn main() {
 
     // This tells that person that controls input index one is responsible for
     // blinding outputs 3, 4.
-    pset.outputs[3].blinding_key = Some(dest_asset_blind_pk);
-    pset.outputs[3].blinder_index = Some(1);
-    pset.outputs[4].blinding_key = Some(change_asset_blind_pk);
-    pset.outputs[4].blinder_index = Some(1);
+    pset.outputs_mut()[3].blinding_key = Some(dest_asset_blind_pk);
+    pset.outputs_mut()[3].blinder_index = Some(1);
+    pset.outputs_mut()[4].blinding_key = Some(change_asset_blind_pk);
+    pset.outputs_mut()[4].blinder_index = Some(1);
 
     // pset after adding the information about the bitcoin input from A
     // and adding B's input. Two inputs and 5 outputs

--- a/examples/raw_blind.rs
+++ b/examples/raw_blind.rs
@@ -293,24 +293,24 @@ fn main() {
     .unwrap();
     // Sign the raw transactions
     // Input zero adds signatures
-    pset.inputs[0]
+    pset.inputs_mut()[0]
         .partial_sigs
         .insert(inp0_pk, inp0_sig.clone());
     assert_eq!(pset, deser_pset(&tests["blinded_one_inp_signed"]));
     // Input one adds signatures
-    pset.inputs[1]
+    pset.inputs_mut()[1]
         .partial_sigs
         .insert(inp1_pk, inp1_sig.clone());
     assert_eq!(pset, deser_pset(&tests["blinded_signed"]));
 
     // Finalize(TODO in miniscript)
-    pset.inputs[0].partial_sigs.clear();
-    pset.inputs[0].final_script_witness = Some(vec![
+    pset.inputs_mut()[0].partial_sigs.clear();
+    pset.inputs_mut()[0].final_script_witness = Some(vec![
         inp0_sig,
         inp0_pk.to_bytes(),
     ]);
-    pset.inputs[1].partial_sigs.clear();
-    pset.inputs[1].final_script_witness = Some(vec![
+    pset.inputs_mut()[1].partial_sigs.clear();
+    pset.inputs_mut()[1].final_script_witness = Some(vec![
         inp1_sig,
         inp1_pk.to_bytes(),
     ]);

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -53,10 +53,10 @@ pub struct PartiallySignedTransaction {
     pub global: Global,
     /// The corresponding key-value map for each input in the unsigned
     /// transaction.
-    pub inputs: Vec<Input>,
+    inputs: Vec<Input>,
     /// The corresponding key-value map for each output in the unsigned
     /// transaction.
-    pub outputs: Vec<Output>,
+    outputs: Vec<Output>,
 }
 
 impl PartiallySignedTransaction {
@@ -96,11 +96,51 @@ impl PartiallySignedTransaction {
         self.inputs.push(inp);
     }
 
+    /// Read accessor to inputs
+    pub fn inputs(&self) -> &[Input] {
+        &self.inputs
+    }
+
+    /// Mutable accessor to inputs
+    pub fn inputs_mut(&mut self) -> &mut [Input] {
+        &mut self.inputs
+    }
+
+    /// Remove the input at `index` and return it if any, otherwise returns None
+    /// This also updates the pset global input count
+    pub fn remove_input(&mut self, index: usize) -> Option<Input> {
+        if self.inputs.get(index).is_some() {
+            self.global.tx_data.input_count -= 1;
+            return Some(self.inputs.remove(index))
+        }
+        None
+    }
+
     /// Add an output to pset. This also updates the
     /// pset global output count
     pub fn add_output(&mut self, out: Output) {
         self.global.tx_data.output_count += 1;
         self.outputs.push(out);
+    }
+
+    /// read accessor to outputs
+    pub fn outputs(&self) -> &[Output] {
+        &self.outputs
+    }
+
+    /// mutable accessor to outputs
+    pub fn outputs_mut(&mut self) -> &mut [Output] {
+        &mut self.outputs
+    }
+
+    /// Remove the output at `index` and return it if any, otherwise returns None
+    /// This also updates the pset global output count
+    pub fn remove_output(&mut self, index: usize) -> Option<Output> {
+        if self.inputs.get(index).is_some() {
+            self.global.tx_data.output_count -= 1;
+            return Some(self.outputs.remove(index))
+        }
+        None
     }
 
     /// Accessor for the number of inputs currently in the PSET


### PR DESCRIPTION
This removes `pub` accessor to PSET inputs and outputs fields, but provides accessor/mutator functions that preserve global count

close #103 