### PR TITLE
Use sort before dedup to achieve uniqueness

### DIFF
--- a/src/pset/map/global.rs
+++ b/src/pset/map/global.rs
@@ -335,6 +335,7 @@ impl Map for Global {
 
         // TODO: Use hashset for efficiency
         self.scalars.extend(other.scalars);
+        self.scalars.sort();
         self.scalars.dedup();
         merge!(elements_tx_modifiable_flag, self, other);
         self.proprietary.extend(other.proprietary);


### PR DESCRIPTION
From https://doc.rust-lang.org/std/vec/struct.Vec.html#method.dedup 

Removes consecutive repeated elements in the vector according to the PartialEq trait implementation.
If the vector is sorted, this removes all duplicates.