### PR TITLE
Fix BlockHeader roundtrip bug on serde binary encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ elementsd = { version="0.3.0", features=["0_21_0","bitcoind_22_0"], optional = t
 rand = "0.6.5"
 serde_test = "1.0"
 serde_json = "1.0"
+serde_cbor = "0.8"  # older than latest version to support 1.36
 ryu = "<1.0.5"
 bincode = "1.3"
 base64 = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ json-contract = [ "serde_json" ]
 bitcoin = "0.27"
 secp256k1-zkp = { version = "0.4.0", features = [ "global-context", "hashes" ] }
 slip21 = "0.2.0"
+secp256k1-sys = "=0.4.1"
 
 # While this dependency is included in bitcoin, we need this to use the macros.
 # We should probably try keep this one in sync with the bitcoin version,

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -453,6 +453,7 @@ impl<'de> Deserialize<'de> for Params {
             "fedpeg_program",
             "fedpegscript",
             "extension_space",
+            "elided_root",
         ];
         d.deserialize_struct("Params", FIELDS, Visitor)
     }
@@ -501,7 +502,7 @@ impl Serialize for Params {
                 ref signblock_witness_limit,
                 ref elided_root,
             } => {
-                let mut st = s.serialize_struct("Params", 2)?;
+                let mut st = s.serialize_struct("Params", 3)?;
                 st.serialize_field("signblockscript", signblockscript)?;
                 st.serialize_field("signblock_witness_limit", signblock_witness_limit)?;
                 st.serialize_field("elided_root", elided_root)?;


### PR DESCRIPTION
close #113 

The number of fields in the Params struct is wrong, this causes an error in roundtrip as shown in the included tests.

Strangely enough, this looks to happen only for binary encoding