### PR TITLE
Update dependancies and release 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.19 - 2022-04-30 "The Taproot Release"
+
+- Taproot support for complex taptrees compatible with elements taproot signature.
+- Taproot psbt support with BIP 371
+hash. Refer to spec [here](https://github.com/ElementsProject/elements/blob/master/doc/taproot-sighash.mediawiki)
+- Support for new tapscript transaction introspection opcodes as per the [spec](https://github.com/ElementsProject/elements/blob/master/doc/tapscript_opcodes.md).
+- Works with bitcoin 0.28 key types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elements"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Andrew Poelstra <apoelstra@blockstream.com>"]
 description = "Library with support for de/serialization, parsing and executing on data structures and network messages related to Elements"
 license = "CC0-1.0"


### PR DESCRIPTION
Dependency upgrade and taproot support implemented in #121. Please review that before making a release. 

This PR is now only has a single commit with the release. 

Fixes #112