### PR TITLE
Add taproot psbt fields according to BIP371

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,9 @@ json-contract = [ "serde_json" ]
 "fuzztarget" = []
 
 [dependencies]
-bitcoin = "0.27"
-secp256k1-zkp = { version = "0.4.0", features = [ "global-context", "hashes" ] }
+bitcoin = "0.28.0"
+secp256k1-zkp = { version = "0.6.0", features = [ "global-context", "bitcoin_hashes" ] }
 slip21 = "0.2.0"
-secp256k1-sys = "=0.4.1"
 
 # While this dependency is included in bitcoin, we need this to use the macros.
 # We should probably try keep this one in sync with the bitcoin version,
@@ -38,7 +37,7 @@ serde = { version = "1.0", features=["derive"], optional = true }
 
 # This should be an optional dev-dependency (only needed for integration tests),
 # but dev-dependency cannot be optional, and without optionality older toolchain try to compile it and fails
-elementsd = { version="0.3.0", features=["0_21_0","bitcoind_22_0"], optional = true }
+elementsd = {version = "0.5.0", features=["0_21_0","bitcoind_22_0"], optional = true }
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/examples/pset_blind_coinjoin.rs
+++ b/examples/pset_blind_coinjoin.rs
@@ -164,7 +164,7 @@ fn main() {
     let dest_btc_txout = TxOut {
         asset: confidential::Asset::Explicit(btc_txout_secrets.sec.asset),
         value: confidential::Value::Explicit(dest_btc_amt),
-        nonce: confidential::Nonce::Confidential(dest_btc_blind_pk.key),
+        nonce: confidential::Nonce::Confidential(dest_btc_blind_pk.inner),
         script_pubkey: Script::new_v0_wsh(&dest_btc_wsh),
         witness: TxOutWitness::default(),
     };
@@ -181,7 +181,7 @@ fn main() {
     let change_btc_txout = TxOut {
         asset: confidential::Asset::Explicit(btc_txout_secrets.sec.asset),
         value: confidential::Value::Explicit(change_amt),
-        nonce: confidential::Nonce::Confidential(change_btc_blind_pk.key),
+        nonce: confidential::Nonce::Confidential(change_btc_blind_pk.inner),
         script_pubkey: Script::new_v0_wsh(&change_btc_wsh),
         witness: TxOutWitness::default(),
     };
@@ -226,7 +226,7 @@ fn main() {
     let dest_asset_txout = TxOut {
         asset: confidential::Asset::Explicit(asset_txout_secrets.sec.asset),
         value: confidential::Value::Explicit(dest_asset_amt),
-        nonce: confidential::Nonce::Confidential(dest_asset_blind_pk.key),
+        nonce: confidential::Nonce::Confidential(dest_asset_blind_pk.inner),
         script_pubkey: Script::new_v0_wsh(&dest_asset_wsh),
         witness: TxOutWitness::default(),
     };
@@ -242,7 +242,7 @@ fn main() {
     let change_asset_txout = TxOut {
         asset: confidential::Asset::Explicit(asset_txout_secrets.sec.asset),
         value: confidential::Value::Explicit(change_asset_amt),
-        nonce: confidential::Nonce::Confidential(change_asset_blind_pk.key),
+        nonce: confidential::Nonce::Confidential(change_asset_blind_pk.inner),
         script_pubkey: Script::new_v0_wsh(&change_asset_wsh),
         witness: TxOutWitness::default(),
     };

--- a/examples/raw_blind.rs
+++ b/examples/raw_blind.rs
@@ -182,7 +182,7 @@ fn main() {
         dest_amt,
         Address::p2wsh(
             &Script::new_v0_wsh(&dest_wsh),
-            Some(dest_blind_pk.key),
+            Some(dest_blind_pk.inner),
             &PARAMS,
         ),
         asset_txout_secrets.sec.asset,
@@ -204,7 +204,7 @@ fn main() {
             change_amt,
             Address::p2wsh(
                 &Script::new_v0_wsh(&change_wsh),
-                Some(change_blind_pk.key),
+                Some(change_blind_pk.inner),
                 &PARAMS,
             ),
             asset_txout_secrets.sec.asset,
@@ -260,7 +260,7 @@ fn main() {
         change_amt,
         Address::p2wsh(
             &Script::new_v0_wsh(&change_wsh),
-            Some(change_blind_pk.key),
+            Some(change_blind_pk.inner),
             &PARAMS,
         ),
         btc_txout_secrets.sec.asset,

--- a/src/blind.rs
+++ b/src/blind.rs
@@ -1040,7 +1040,7 @@ mod tests {
                 &PrivateKey {
                     compressed: true,
                     network: Network::Regtest,
-                    key: sk,
+                    inner: sk,
                 },
             );
             let blinding_sk = SecretKey::new(&mut thread_rng());
@@ -1049,11 +1049,11 @@ mod tests {
                 &PrivateKey {
                     compressed: true,
                     network: Network::Regtest,
-                    key: blinding_sk,
+                    inner: blinding_sk,
                 },
             );
             (
-                Address::p2wpkh(&pk, Some(blinding_pk.key), &AddressParams::ELEMENTS),
+                Address::p2wpkh(&pk, Some(blinding_pk.inner), &AddressParams::ELEMENTS),
                 blinding_sk,
             )
         };

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -30,6 +30,9 @@ pub use bitcoin::{self, consensus::encode::MAX_VEC_SIZE};
 
 // Use the ReadExt/WriteExt traits as is from upstream
 pub use bitcoin::consensus::encode::{ReadExt, WriteExt};
+
+use taproot::TapLeafHash;
+
 /// Encoding error
 #[derive(Debug)]
 pub enum Error {
@@ -271,6 +274,7 @@ macro_rules! impl_vec {
 impl_vec!(TxIn);
 impl_vec!(TxOut);
 impl_vec!(Transaction);
+impl_vec!(TapLeafHash);
 
 
 macro_rules! impl_option {
@@ -343,6 +347,18 @@ impl Encodable for sha256::Hash {
 }
 
 impl Decodable for sha256::Hash {
+    fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, Error> {
+        Ok(Self::from_inner(<<Self as Hash>::Inner>::consensus_decode(d)?))
+    }
+}
+
+impl Encodable for TapLeafHash {
+    fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, Error> {
+        self.into_inner().consensus_encode(s)
+    }
+}
+
+impl Decodable for TapLeafHash {
     fn consensus_decode<D: io::BufRead>(d: D) -> Result<Self, Error> {
         Ok(Self::from_inner(<<Self as Hash>::Inner>::consensus_decode(d)?))
     }

--- a/src/pset/map/mod.rs
+++ b/src/pset/map/mod.rs
@@ -36,3 +36,4 @@ pub use self::global::Global;
 pub use self::global::TxData as GlobalTxData;
 pub use self::input::Input;
 pub use self::output::Output;
+pub use self::output::TapTree;

--- a/src/pset/map/output.rs
+++ b/src/pset/map/output.rs
@@ -160,12 +160,12 @@ impl Output{
         }
         if txout.is_partially_blinded() {
             rv.ecdh_pubkey = txout.nonce.commitment().map(|pk| bitcoin::PublicKey {
-                key: pk,
+                inner: pk,
                 compressed: true, // always serialize none as compressed pk
             });
         } else {
             rv.blinding_key = txout.nonce.commitment().map(|pk| bitcoin::PublicKey {
-                key: pk,
+                inner: pk,
                 compressed: true, // always serialize none as compressed pk
             });
         }
@@ -189,9 +189,9 @@ impl Output{
                 (None, None) => confidential::Value::Null,
             },
             nonce: if self.is_partially_blinded() {
-                self.ecdh_pubkey.map(|pk| confidential::Nonce::from(pk.key))
+                self.ecdh_pubkey.map(|pk| confidential::Nonce::from(pk.inner))
             } else {
-                self.blinding_key.map(|pk| confidential::Nonce::from(pk.key))
+                self.blinding_key.map(|pk| confidential::Nonce::from(pk.inner))
             }.unwrap_or_default(),
             script_pubkey: self.script_pubkey.clone(),
             witness: TxOutWitness {

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -268,7 +268,7 @@ impl PartiallySignedTransaction {
                     (None, None) => return Err(Error::MissingOutputAsset),
                 },
                 nonce: out.ecdh_pubkey
-                    .map(|x| confidential::Nonce::from(x.key))
+                    .map(|x| confidential::Nonce::from(x.inner))
                     .unwrap_or_default(),
                 script_pubkey: out.script_pubkey.clone(),
                 witness: TxOutWitness {
@@ -400,7 +400,7 @@ impl PartiallySignedTransaction {
                     secp,
                     self.outputs[i]
                         .blinding_key
-                        .map(|x| x.key)
+                        .map(|x| x.inner)
                         .ok_or(PsetBlindError::MustHaveExplicitTxOut(i))?,
                     &spent_utxo_secrets,
                 )
@@ -415,7 +415,7 @@ impl PartiallySignedTransaction {
                 self.outputs[i].amount_comm = txout.value.commitment();
                 self.outputs[i].asset_comm = txout.asset.commitment();
                 self.outputs[i].ecdh_pubkey = txout.nonce.commitment().map(|pk| bitcoin::PublicKey{
-                    key: pk,
+                    inner: pk,
                     compressed: true
                 });
                 let asset_id = self.outputs[i].asset.ok_or(PsetBlindError::MustHaveExplicitTxOut(i))?;
@@ -525,7 +525,7 @@ impl PartiallySignedTransaction {
         let receiver_blinding_pk = &self.outputs[last_out_index]
             .blinding_key
             .ok_or(PsetBlindError::MustHaveExplicitTxOut(last_out_index))?;
-        let (nonce, shared_secret) = confidential::Nonce::new_confidential(rng, secp, &receiver_blinding_pk.key);
+        let (nonce, shared_secret) = confidential::Nonce::new_confidential(rng, secp, &receiver_blinding_pk.inner);
 
         let message = RangeProofMessage { asset, bf: out_abf };
         let rangeproof = RangeProof::new(
@@ -580,7 +580,7 @@ impl PartiallySignedTransaction {
             self.outputs[last_out_index].amount_comm = Some(value_commitment);
             self.outputs[last_out_index].asset_comm = Some(out_asset_commitment);
             self.outputs[last_out_index].ecdh_pubkey = nonce.commitment().map(|pk| bitcoin::PublicKey{
-                key: pk,
+                inner: pk,
                 compressed: true
             });
             let asset_id = self.outputs[last_out_index].asset.ok_or(PsetBlindError::MustHaveExplicitTxOut(last_out_index))?;

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -42,7 +42,7 @@ use blind::ConfidentialTxOutError;
 use blind::{BlindAssetProofs, BlindValueProofs};
 
 pub use self::error::{Error, PsetBlindError};
-pub use self::map::{Global, GlobalTxData, Input, Output};
+pub use self::map::{Global, GlobalTxData, Input, Output, TapTree};
 use self::map::Map;
 
 /// A Partially Signed Transaction.

--- a/src/pset/serialize.rs
+++ b/src/pset/serialize.rs
@@ -21,13 +21,20 @@ use std::io;
 
 use bitcoin::{self, PublicKey, VarInt};
 use {Script, SigHashType, Transaction, TxOut, Txid, BlockHash, AssetId};
-use encode::{self, serialize, deserialize, Decodable};
+use encode::{self, serialize, deserialize, Decodable, Encodable, deserialize_partial};
 use bitcoin::util::bip32::{ChildNumber, Fingerprint, KeySource};
 use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use pset;
 use bitcoin::hashes::hex::ToHex;
 use confidential;
 use secp256k1_zkp::{self, RangeProof, SurjectionProof, Tweak};
+
+use taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
+use schnorr;
+use super::map::TapTree;
+
+use taproot::TaprootBuilder;
+use sighash::SchnorrSigHashType;
 
 /// A trait for serializing a value as raw data for insertion into PSET
 /// key-value pairs.
@@ -62,9 +69,14 @@ impl_pset_hash_de_serialize!(sha256::Hash);
 impl_pset_hash_de_serialize!(hash160::Hash);
 impl_pset_hash_de_serialize!(sha256d::Hash);
 impl_pset_hash_de_serialize!(BlockHash);
+impl_pset_hash_de_serialize!(TapLeafHash);
+impl_pset_hash_de_serialize!(TapBranchHash);
 
 // required for pegin bitcoin::Transactions
 impl_pset_de_serialize!(bitcoin::Transaction);
+
+// taproot
+impl_pset_de_serialize!(Vec<TapLeafHash>);
 
 impl Serialize for Tweak {
     fn serialize(&self) -> Vec<u8> {
@@ -111,7 +123,7 @@ impl Deserialize for PublicKey {
 
 impl Serialize for KeySource {
     fn serialize(&self) -> Vec<u8> {
-        let mut rv: Vec<u8> = Vec::with_capacity(4 + 4 * (self.1).as_ref().len());
+        let mut rv: Vec<u8> = Vec::with_capacity(key_source_len(&self));
 
         rv.append(&mut self.0.to_bytes().to_vec());
 
@@ -264,4 +276,171 @@ impl Deserialize for SurjectionProof {
         SurjectionProof::from_slice(&bytes)
             .map_err(|_| encode::Error::ParseFailed("Invalid SurjectionProof"))
     }
+}
+
+// Taproot related ser/deser
+impl Serialize for bitcoin::XOnlyPublicKey {
+    fn serialize(&self) -> Vec<u8> {
+        bitcoin::XOnlyPublicKey::serialize(&self).to_vec()
+    }
+}
+
+impl Deserialize for bitcoin::XOnlyPublicKey {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        bitcoin::XOnlyPublicKey::from_slice(bytes)
+            .map_err(|_| encode::Error::ParseFailed("Invalid xonly public key"))
+    }
+}
+
+impl Serialize for schnorr::SchnorrSig  {
+    fn serialize(&self) -> Vec<u8> {
+        self.to_vec()
+    }
+}
+
+impl Deserialize for schnorr::SchnorrSig {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        match bytes.len() {
+            65 => {
+                let hash_ty = SchnorrSigHashType::from_u8(bytes[64])
+                    .ok_or(encode::Error::ParseFailed("Invalid Sighash type"))?;
+                let sig = secp256k1_zkp::schnorr::Signature::from_slice(&bytes[..64])
+                    .map_err(|_| encode::Error::ParseFailed("Invalid Schnorr signature"))?;
+                Ok(schnorr::SchnorrSig{ sig, hash_ty })
+            }
+            64 => {
+                let sig = secp256k1_zkp::schnorr::Signature::from_slice(&bytes[..64])
+                    .map_err(|_| encode::Error::ParseFailed("Invalid Schnorr signature"))?;
+                    Ok(schnorr::SchnorrSig{ sig, hash_ty: SchnorrSigHashType::Default })
+            }
+            _ => Err(encode::Error::ParseFailed("Invalid Schnorr signature len"))
+        }
+    }
+}
+
+impl Serialize for (bitcoin::XOnlyPublicKey, TapLeafHash) {
+    fn serialize(&self) -> Vec<u8> {
+        let ser_pk = self.0.serialize();
+        let mut buf = Vec::with_capacity(ser_pk.len() + self.1.as_ref().len());
+        buf.extend(&ser_pk);
+        buf.extend(self.1.as_ref());
+        buf
+    }
+}
+
+impl Deserialize for (bitcoin::XOnlyPublicKey, TapLeafHash) {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        if bytes.len() < 32 {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
+        }
+        let a: bitcoin::XOnlyPublicKey = Deserialize::deserialize(&bytes[..32])?;
+        let b: TapLeafHash = Deserialize::deserialize(&bytes[32..])?;
+        Ok((a, b))
+    }
+}
+
+impl Serialize for ControlBlock {
+    fn serialize(&self) -> Vec<u8> {
+        ControlBlock::serialize(&self)
+    }
+}
+
+impl Deserialize for ControlBlock {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        Self::from_slice(bytes)
+            .map_err(|_| encode::Error::ParseFailed("Invalid control block"))
+    }
+}
+
+// Versioned Script
+impl Serialize for (Script, LeafVersion) {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.0.len() + 1);
+        buf.extend(self.0.as_bytes());
+        buf.push(self.1.as_u8());
+        buf
+    }
+}
+
+impl Deserialize for (Script, LeafVersion) {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        if bytes.is_empty() {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
+        }
+        // The last byte is LeafVersion.
+        let script = Script::deserialize(&bytes[..bytes.len() - 1])?;
+        let leaf_ver = LeafVersion::from_u8(bytes[bytes.len() - 1])
+            .map_err(|_| encode::Error::ParseFailed("invalid leaf version"))?;
+        Ok((script, leaf_ver))
+    }
+}
+
+
+impl Serialize for (Vec<TapLeafHash>, KeySource) {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity( 32 * self.0.len() + key_source_len(&self.1));
+        self.0.consensus_encode(&mut buf).expect("Vecs don't error allocation");
+        // TODO: Add support for writing into a writer for key-source
+        buf.extend(self.1.serialize());
+        buf
+    }
+}
+
+impl Deserialize for (Vec<TapLeafHash>, KeySource) {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        let (leafhash_vec, consumed) = deserialize_partial::<Vec::<TapLeafHash>>(&bytes)?;
+        let key_source = KeySource::deserialize(&bytes[consumed..])?;
+        Ok((leafhash_vec, key_source))
+    }
+}
+
+impl Serialize for TapTree {
+    fn serialize(&self) -> Vec<u8> {
+        match (self.0.branch().len(), self.0.branch().last()) {
+            (1, Some(Some(root))) => {
+                let mut buf = Vec::new();
+                for leaf_info in root.leaves.iter() {
+                    // # Cast Safety:
+                    //
+                    // TaprootMerkleBranch can only have len atmost 128(TAPROOT_CONTROL_MAX_NODE_COUNT).
+                    // safe to cast from usize to u8
+                    buf.push(leaf_info.merkle_branch.as_inner().len() as u8);
+                    buf.push(leaf_info.ver.as_u8());
+                    leaf_info.script.consensus_encode(&mut buf).expect("Vecs dont err");
+                }
+                buf
+            }
+        // This should be unreachable as we Taptree is already finalized
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Deserialize for TapTree {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        let mut builder = TaprootBuilder::new();
+        let mut bytes_iter = bytes.iter();
+        while let Some(depth) = bytes_iter.next() {
+            let version = bytes_iter.next().ok_or(encode::Error::ParseFailed("Invalid Taproot Builder"))?;
+            let (script, consumed) = deserialize_partial::<Script>(bytes_iter.as_slice())?;
+            if consumed > 0 {
+                bytes_iter.nth(consumed - 1);
+            }
+
+            let leaf_version = LeafVersion::from_u8(*version)
+                .map_err(|_| encode::Error::ParseFailed("Leaf Version Error"))?;
+            builder = builder.add_leaf_with_ver(usize::from(*depth), script, leaf_version)
+                .map_err(|_| encode::Error::ParseFailed("Tree not in DFS order"))?;
+        }
+        if builder.is_complete() {
+            Ok(TapTree(builder))
+        } else {
+            Err(encode::Error::ParseFailed("Incomplete taproot Tree"))
+        }
+    }
+}
+
+// Helper function to compute key source len
+fn key_source_len(key_source: &KeySource) -> usize {
+    4 + 4 * (key_source.1).as_ref().len()
 }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -93,6 +93,7 @@ impl TweakedPublicKey {
 
 /// A BIP340-341 serialized schnorr signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SchnorrSig {
     /// The underlying schnorr signature
     pub sig: secp256k1_zkp::schnorr::Signature,

--- a/src/script.rs
+++ b/src/script.rs
@@ -748,9 +748,9 @@ impl Builder {
     /// Pushes a public key
     pub fn push_key(self, key: &PublicKey) -> Builder {
         if key.compressed {
-            self.push_slice(&key.key.serialize()[..])
+            self.push_slice(&key.inner.serialize()[..])
         } else {
-            self.push_slice(&key.key.serialize_uncompressed()[..])
+            self.push_slice(&key.inner.serialize_uncompressed()[..])
         }
     }
 

--- a/src/sighash.rs
+++ b/src/sighash.rs
@@ -817,6 +817,7 @@ impl<'a> Encodable for Annex<'a> {
 /// Hashtype of an input's signature, encoded in the last byte of the signature
 /// Fixed values so they can be casted as integer types for encoding
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SchnorrSigHashType {
     /// 0x0: Used when not explicitly specified, defaulting to [`SchnorrSigHashType::All`]
     Default = 0x00,

--- a/src/slip77.rs
+++ b/src/slip77.rs
@@ -42,7 +42,7 @@ impl MasterBlindingKey {
     ) -> sha256d::Hash {
         let blinding_private_key = self.derive_blinding_key(script_pubkey);
         let shared_secret = secp256k1_zkp::ecdh::SharedSecret::new(&other, &blinding_private_key);
-        sha256d::Hash::hash(&shared_secret[..])
+        sha256d::Hash::hash(shared_secret.as_ref())
     }
 }
 

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -333,6 +333,7 @@ impl TaprootSpendInfo {
 /// branches in a DFS(Depth first search) walk to construct this tree.
 // Similar to Taproot Builder in bitcoin core
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TaprootBuilder {
     // The following doc-comment is from bitcoin core, but modified for rust
     // The comment below describes the current state of the builder for a given tree.
@@ -378,6 +379,16 @@ impl TaprootBuilder {
     pub fn new() -> Self {
         TaprootBuilder { branch: vec![] }
     }
+
+    /// Check if the builder is a complete tree
+    pub fn is_complete(&self) -> bool {
+        self.branch.len() == 1 && self.branch[0].is_some()
+    }
+
+    pub(crate) fn branch(&self) -> &[Option<NodeInfo>]{
+        &self.branch
+    }
+
     /// Just like [`TaprootBuilder::add_leaf`] but allows to specify script version
     pub fn add_leaf_with_ver(
         self,
@@ -470,26 +481,27 @@ impl TaprootBuilder {
     }
 }
 
-// Internally used structure to represent the node information in taproot tree
+/// Structure to represent the node information in taproot tree
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct NodeInfo {
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct NodeInfo {
     /// Merkle Hash for this node
-    hash: sha256::Hash,
+    pub(crate) hash: sha256::Hash,
     /// information about leaves inside this node
-    leaves: Vec<LeafInfo>,
+    pub(crate) leaves: Vec<LeafInfo>,
 }
 
 impl NodeInfo {
-    // Create a new NodeInfo with omitted/hidden info
-    fn new_hidden(hash: sha256::Hash) -> Self {
+    /// Creates a new NodeInfo with omitted/hidden info
+    pub fn new_hidden(hash: sha256::Hash) -> Self {
         Self {
             hash: hash,
             leaves: vec![],
         }
     }
 
-    // Create a new leaf with NodeInfo
-    fn new_leaf_with_ver(script: Script, ver: LeafVersion) -> Self {
+    /// Creates a new leaf with NodeInfo
+    pub fn new_leaf_with_ver(script: Script, ver: LeafVersion) -> Self {
         let leaf = LeafInfo::new(script, ver);
         Self {
             hash: leaf.hash(),
@@ -497,8 +509,8 @@ impl NodeInfo {
         }
     }
 
-    // Combine two NodeInfo's to create a new parent
-    fn combine(a: Self, b: Self) -> Result<Self, TaprootBuilderError> {
+    /// Combines two NodeInfo's to create a new parent
+    pub fn combine(a: Self, b: Self) -> Result<Self, TaprootBuilderError> {
         let mut all_leaves = Vec::with_capacity(a.leaves.len() + b.leaves.len());
         for mut a_leaf in a.leaves {
             a_leaf.merkle_branch.push(b.hash)?; // add hashing partner
@@ -523,20 +535,21 @@ impl NodeInfo {
     }
 }
 
-// Internally used structure to store information about taproot leaf node
+/// Data Structure to store information about taproot leaf node
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct LeafInfo {
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct LeafInfo {
     // The underlying script
-    script: Script,
+    pub(crate) script: Script,
     // The leaf version
-    ver: LeafVersion,
+    pub(crate) ver: LeafVersion,
     // The merkle proof(hashing partners) to get this node
-    merkle_branch: TaprootMerkleBranch,
+    pub(crate) merkle_branch: TaprootMerkleBranch,
 }
 
 impl LeafInfo {
-    // Create an instance of Self from Script with default version and no merkle branch
-    fn new(script: Script, ver: LeafVersion) -> Self {
+    /// Creates an instance of Self from Script with default version and no merkle branch
+    pub fn new(script: Script, ver: LeafVersion) -> Self {
         Self {
             script: script,
             ver: ver,
@@ -544,7 +557,7 @@ impl LeafInfo {
         }
     }
 
-    // Compute a leaf hash for the given leaf
+    // Computes a leaf hash for the given leaf
     fn hash(&self) -> sha256::Hash {
         let leaf_hash = TapLeafHash::from_script(&self.script, self.ver);
         sha256::Hash::from_inner(leaf_hash.into_inner())
@@ -555,6 +568,7 @@ impl LeafInfo {
 // The type of hash is sha256::Hash because the vector might contain
 // both TapBranchHash and TapLeafHash
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TaprootMerkleBranch(Vec<sha256::Hash>);
 
 impl TaprootMerkleBranch {
@@ -626,6 +640,7 @@ impl TaprootMerkleBranch {
 
 /// Control Block data structure used in Tapscript satisfaction
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ControlBlock {
     /// The tapleaf version,
     pub leaf_version: LeafVersion,
@@ -732,6 +747,7 @@ impl ControlBlock {
 
 /// The leaf version for tapleafs
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LeafVersion(u8);
 
 impl Default for LeafVersion {


### PR DESCRIPTION
These work directly with elements 23.0(24.0?) after it has been released.
There are no changes to elements specific proprietary fields, only main
bitcoin psbt fields.


Most of this is just copy pasting code from rust-bitcoin and making it work :) . For reference: 
https://github.com/bitcoin/bips/blob/master/bip-0371.mediawiki. 

Unfortunately, this is the only supporting implementation. So, there are no test vectors to check against. 