### PR TITLE
Deprecate get_ prefix for Block and Transaction methods

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -372,7 +372,13 @@ impl Block {
     }
 
     /// Get the size of the block
+    #[deprecated(since = "0.19.1", note = "Please use `Block::size` instead.")]
     pub fn get_size(&self) -> usize {
+        self.size()
+    }
+
+    /// Get the size of the block
+    pub fn size(&self) -> usize {
         // The size of the header + the size of the varint with the tx count + the txs themselves
         let base_size = serialize(&self.header).len() + VarInt(self.txdata.len() as u64).len();
         let txs_size: usize = self.txdata.iter().map(Transaction::get_size).sum();
@@ -380,7 +386,13 @@ impl Block {
     }
 
     /// Get the weight of the block
+    #[deprecated(since = "0.19.1", note = "Please use `Block::weight` instead.")]
     pub fn get_weight(&self) -> usize {
+        self.weight()
+    }
+
+    /// Get the weight of the block
+    pub fn weight(&self) -> usize {
         let base_weight = 4 * (serialize(&self.header).len() + VarInt(self.txdata.len() as u64).len());
         let txs_weight: usize = self.txdata.iter().map(Transaction::get_weight).sum();
         base_weight + txs_weight

--- a/src/block.rs
+++ b/src/block.rs
@@ -381,7 +381,7 @@ impl Block {
     pub fn size(&self) -> usize {
         // The size of the header + the size of the varint with the tx count + the txs themselves
         let base_size = serialize(&self.header).len() + VarInt(self.txdata.len() as u64).len();
-        let txs_size: usize = self.txdata.iter().map(Transaction::get_size).sum();
+        let txs_size: usize = self.txdata.iter().map(Transaction::size).sum();
         base_size + txs_size
     }
 
@@ -394,7 +394,7 @@ impl Block {
     /// Get the weight of the block
     pub fn weight(&self) -> usize {
         let base_weight = 4 * (serialize(&self.header).len() + VarInt(self.txdata.len() as u64).len());
-        let txs_weight: usize = self.txdata.iter().map(Transaction::get_weight).sum();
+        let txs_weight: usize = self.txdata.iter().map(Transaction::weight).sum();
         base_weight + txs_weight
     }
 }
@@ -473,8 +473,8 @@ mod tests {
         assert_eq!(block.header.version, 0x20000000);
         assert_eq!(block.header.height, 2);
         assert_eq!(block.txdata.len(), 1);
-        assert_eq!(block.get_size(), serialize(&block).len());
-        assert_eq!(block.get_weight(), 1089);
+        assert_eq!(block.size(), serialize(&block).len());
+        assert_eq!(block.weight(), 1089);
 
         // Block with 3 transactions ... the rangeproofs are very large :)
         let block: Block = hex_deserialize!(
@@ -685,7 +685,7 @@ mod tests {
         assert_eq!(block.header.version, 0x20000000);
         assert_eq!(block.header.height, 1);
         assert_eq!(block.txdata.len(), 3);
-        assert_eq!(block.get_size(), serialize(&block).len());
+        assert_eq!(block.size(), serialize(&block).len());
 
         // 2-of-3 signed block from Liquid integration tests
         let block: Block = hex_deserialize!(

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -589,16 +589,29 @@ impl Transaction {
 
     /// Get the "weight" of this transaction; roughly equivalent to BIP141, in that witness data is
     /// counted as 1 while non-witness data is counted as 4.
+    #[deprecated(since = "0.19.1", note = "Please use `Transaction::weight` instead.")]
     pub fn get_weight(&self) -> usize {
-        self.get_scaled_size(4)
+        self.weight()
+    }
+
+    /// Get the "weight" of this transaction; roughly equivalent to BIP141, in that witness data is
+    /// counted as 1 while non-witness data is counted as 4.
+    pub fn weight(&self) -> usize {
+        self.scaled_size(4)
     }
 
     /// Gets the regular byte-wise consensus-serialized size of this transaction.
+    #[deprecated(since = "0.19.1", note = "Please use `Transaction::size` instead.")]
     pub fn get_size(&self) -> usize {
-        self.get_scaled_size(1)
+        self.size()
     }
 
-    fn get_scaled_size(&self, scale_factor: usize) -> usize {
+    /// Gets the regular byte-wise consensus-serialized size of this transaction.
+    pub fn size(&self) -> usize {
+        self.scaled_size(1)
+    }
+
+    fn scaled_size(&self, scale_factor: usize) -> usize {
         let witness_flag = self.has_witness();
 
         let input_weight = self.input.iter().map(|input| {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -990,8 +990,8 @@ mod tests {
         );
         assert_eq!(tx.input.len(), 1);
         assert_eq!(tx.output.len(), 2);
-        assert_eq!(tx.get_size(), serialize(&tx).len());
-        assert_eq!(tx.get_weight(), tx.get_size() * 4);
+        assert_eq!(tx.size(), serialize(&tx).len());
+        assert_eq!(tx.weight(), tx.size() * 4);
         assert_eq!(tx.output[0].is_fee(), false);
         assert_eq!(tx.output[1].is_fee(), true);
         assert_eq!(tx.output[0].value, confidential::Value::Explicit(9999996700));
@@ -1200,8 +1200,8 @@ mod tests {
             tx.txid().to_string(),
             "d606b563122409191e3b114a41d5611332dc58237ad5d2dccded302664fd56c4"
         );
-        assert_eq!(tx.get_size(), serialize(&tx).len());
-        assert_eq!(tx.get_weight(), 7296);
+        assert_eq!(tx.size(), serialize(&tx).len());
+        assert_eq!(tx.weight(), 7296);
         assert_eq!(tx.input.len(), 1);
         assert_eq!(tx.input[0].is_coinbase(), false);
         assert_eq!(tx.is_coinbase(), false);
@@ -1243,8 +1243,8 @@ mod tests {
             "cc1f895908af2509e55719e662acf4a50ca4dcf0454edd718459241745e2b0aa"
         );
         assert_eq!(tx.input.len(), 1);
-        assert_eq!(tx.get_size(), serialize(&tx).len());
-        assert_eq!(tx.get_weight(), 769);
+        assert_eq!(tx.size(), serialize(&tx).len());
+        assert_eq!(tx.weight(), 769);
         assert_eq!(tx.input[0].is_coinbase(), true);
         assert_eq!(!tx.input[0].is_pegin(), true);
         assert_eq!(tx.input[0].pegin_data(), None);


### PR DESCRIPTION
To match the changes introduced in https://github.com/rust-bitcoin/rust-bitcoin/pull/861.

This allows using unified code with the same methods for both `elements::{Transaction,Block}` and `bitcoin::{Transaction,Block}` (behind different features), without triggering rust-bitcoin's deprecation warnings for the `get_`-prefixed methods.

Note that there are other instances of `get_`-prefixed methods in the rust-elements codebase. I only updated the ones needed for compatibility with the changes made in rust-bitcoin.