### PR TITLE
upgrade to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "CC0-1.0"
 homepage = "https://github.com/ElementsProject/rust-elements/"
 repository = "https://github.com/ElementsProject/rust-elements/"
 documentation = "https://docs.rs/elements/"
+edition = "2018"
 
 [features]
 default = [ "json-contract" ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "elements-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
+edition = "2018"
 
 [package.metadata]
 cargo-fuzz = true

--- a/src/address.rs
+++ b/src/address.rs
@@ -29,13 +29,13 @@ use secp256k1_zkp::Verification;
 #[cfg(feature = "serde")]
 use serde;
 
-use blech32;
+use crate::blech32;
 
-use schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
-use taproot::TapBranchHash;
+use crate::schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
+use crate::taproot::TapBranchHash;
 
-use {PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash};
-use {opcodes, script};
+use crate::{PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash};
+use crate::{opcodes, script};
 
 /// Encoding error
 #[derive(Debug, PartialEq)]
@@ -744,7 +744,7 @@ mod test {
     use super::*;
     use bitcoin::util::key;
     use secp256k1_zkp::{PublicKey, Secp256k1};
-    use Script;
+    use crate::Script;
     #[cfg(feature = "serde")]
     use serde_json;
 

--- a/src/blind.rs
+++ b/src/blind.rs
@@ -20,14 +20,14 @@ use std::{self, fmt};
 use secp256k1_zkp::{self, PedersenCommitment, SecretKey, Tag, Tweak, Verification, ZERO_TWEAK, rand::{CryptoRng, RngCore}};
 use secp256k1_zkp::{Generator, RangeProof, Secp256k1, Signing, SurjectionProof};
 
-use AddressParams;
+use crate::AddressParams;
 
-use {Address, AssetId, Transaction, TxOut, TxOutWitness,
+use crate::{Address, AssetId, Transaction, TxOut, TxOutWitness,
     confidential::{Asset, AssetBlindingFactor, Nonce, Value,
     ValueBlindingFactor
 }};
 
-use hashes;
+use crate::hashes;
 
 /// Transaction Output related errors
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -981,13 +981,13 @@ impl BlindAssetProofs for SurjectionProof {
 
 #[cfg(test)]
 mod tests {
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
     use rand::thread_rng;
     use secp256k1_zkp::SECP256K1;
     use super::*;
-    use encode::deserialize;
-    use confidential;
-    use Script;
+    use crate::encode::deserialize;
+    use crate::confidential;
+    use crate::Script;
     use bitcoin::{self, Network, PrivateKey, PublicKey};
 
     #[test]

--- a/src/block.rs
+++ b/src/block.rs
@@ -21,10 +21,10 @@ use bitcoin::hashes::{Hash, sha256};
 #[cfg(feature = "serde")] use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")] use std::fmt;
 
-use dynafed;
-use Transaction;
-use encode::{self, Encodable, Decodable, serialize};
-use {BlockHash, Script, TxMerkleNode, VarInt};
+use crate::dynafed;
+use crate::Transaction;
+use crate::encode::{self, Encodable, Decodable, serialize};
+use crate::{BlockHash, Script, TxMerkleNode, VarInt};
 
 /// Data related to block signatures
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -283,7 +283,7 @@ impl BlockHeader {
                     current.calculate_root().into_inner(),
                     proposed.calculate_root().into_inner(),
                 ];
-                Some(::fast_merkle_root::fast_merkle_root(&leaves[..]))
+                Some(crate::fast_merkle_root::fast_merkle_root(&leaves[..]))
             }
         }
     }
@@ -401,8 +401,8 @@ impl Block {
 
 #[cfg(test)]
 mod tests {
-    use Block;
-    use hashes::hex::FromHex;
+    use crate::Block;
+    use crate::hashes::hex::FromHex;
 
     use super::*;
 

--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -17,7 +17,7 @@
 //! Structures representing Pedersen commitments of various types
 //!
 
-use hashes::{sha256d, Hash, hex};
+use crate::hashes::{sha256d, Hash, hex};
 use secp256k1_zkp::{self, CommitmentSecrets, Generator, PedersenCommitment,
     PublicKey, Secp256k1, SecretKey, Signing, Tweak, ZERO_TWEAK,
     compute_adaptive_blinding_factor,
@@ -28,8 +28,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use std::{fmt, io, ops::{AddAssign, Neg}, str};
 
-use encode::{self, Decodable, Encodable};
-use issuance::AssetId;
+use crate::encode::{self, Decodable, Encodable};
+use crate::issuance::AssetId;
 
 /// A CT commitment to an amount
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -20,8 +20,8 @@ use bitcoin;
 use bitcoin::hashes::{Hash, sha256, sha256d};
 #[cfg(feature = "serde")] use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use encode::{self, Encodable, Decodable};
-use Script;
+use crate::encode::{self, Encodable, Decodable};
+use crate::Script;
 
 /// Dynamic federations paramaters, as encoded in a block header
 #[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -212,7 +212,7 @@ impl Params {
                     serialize_hash(fedpegscript).into_inner(),
                     serialize_hash(extension_space).into_inner(),
                 ];
-                ::fast_merkle_root::fast_merkle_root(&leaves[..])
+                crate::fast_merkle_root::fast_merkle_root(&leaves[..])
             },
         }
     }
@@ -233,13 +233,13 @@ impl Params {
             serialize_hash(self.signblockscript().unwrap()).into_inner(),
             serialize_hash(&self.signblock_witness_limit().unwrap()).into_inner(),
         ];
-        let compact_root = ::fast_merkle_root::fast_merkle_root(&leaves[..]);
+        let compact_root = crate::fast_merkle_root::fast_merkle_root(&leaves[..]);
 
         let leaves = [
             compact_root.into_inner(),
             self.extra_root().into_inner(),
         ];
-        ::fast_merkle_root::fast_merkle_root(&leaves[..])
+        crate::fast_merkle_root::fast_merkle_root(&leaves[..])
     }
 
     /// Turns paramers into compact parameters.
@@ -649,8 +649,8 @@ mod tests {
             "8eb1b83cce69a3d8b0bfb7fbe77ae8f1d24b57a9cae047b8c0aba084ad878249"
         );
 
-        let header = ::block::BlockHeader{
-            ext: ::block::ExtData::Dynafed {
+        let header = crate::block::BlockHeader{
+            ext: crate::block::ExtData::Dynafed {
                 current: compact_entry,
                 proposed: full_entry,
                 signblock_witness: vec![],

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -17,21 +17,21 @@
 
 use std::io::Cursor;
 use std::{error, fmt, io, mem};
-use hashes::{self, Hash};
+use crate::hashes::{self, Hash};
 
 use bitcoin::consensus::encode as btcenc;
 use bitcoin::hashes::sha256;
 use secp256k1_zkp::{self, RangeProof, SurjectionProof, Tweak};
 
-use transaction::{Transaction, TxIn, TxOut};
-use pset;
+use crate::transaction::{Transaction, TxIn, TxOut};
+use crate::pset;
 
 pub use bitcoin::{self, consensus::encode::MAX_VEC_SIZE};
 
 // Use the ReadExt/WriteExt traits as is from upstream
 pub use bitcoin::consensus::encode::{ReadExt, WriteExt};
 
-use taproot::TapLeafHash;
+use crate::taproot::TapLeafHash;
 
 /// Encoding error
 #[derive(Debug)]
@@ -230,7 +230,7 @@ impl_upstream!([u8; 33]);
 impl_upstream!(Vec<u8>);
 impl_upstream!(Vec<Vec<u8>>);
 impl_upstream!(btcenc::VarInt);
-impl_upstream!(::hashes::sha256d::Hash);
+impl_upstream!(crate::hashes::sha256d::Hash);
 impl_upstream!(bitcoin::Transaction);
 impl_upstream!(bitcoin::BlockHash);
 

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -16,7 +16,7 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl $crate::encode::Encodable for $thing {
             #[inline]
-            fn consensus_encode<S: $crate::std::io::Write>(&self, mut s: S) -> Result<usize, $crate::encode::Error> {
+            fn consensus_encode<S: std::io::Write>(&self, mut s: S) -> Result<usize, $crate::encode::Error> {
                 let mut ret = 0;
                 $( ret += self.$field.consensus_encode(&mut s)?; )+
                 Ok(ret)
@@ -25,7 +25,7 @@ macro_rules! impl_consensus_encoding {
 
         impl $crate::encode::Decodable for $thing {
             #[inline]
-            fn consensus_decode<D: $crate::std::io::Read>(mut d: D) -> Result<$thing, $crate::encode::Error> {
+            fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<$thing, $crate::encode::Error> {
                 Ok($thing {
                     $( $field: $crate::encode::Decodable::consensus_decode(&mut d)?, )+
                 })
@@ -42,7 +42,7 @@ macro_rules! serde_struct_impl {
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
-                use $crate::std::fmt::{self, Formatter};
+                use std::fmt::{self, Formatter};
                 use $crate::serde::de::IgnoredAny;
 
                 #[allow(non_camel_case_types)]
@@ -442,6 +442,6 @@ macro_rules! hex_script(
     ($e:expr) => ({
         let v: Vec<u8> = ::bitcoin::hashes::hex::FromHex::from_hex($e)
             .expect("hex decoding");
-        ::Script::from(v)
+        crate::Script::from(v)
     })
 );

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -19,10 +19,10 @@ use std::str::FromStr;
 
 use bitcoin::hashes::{self, hex, sha256, sha256d, Hash};
 
-use encode::{self, Encodable, Decodable};
-use fast_merkle_root::fast_merkle_root;
+use crate::encode::{self, Encodable, Decodable};
+use crate::fast_merkle_root::fast_merkle_root;
 use secp256k1_zkp::Tag;
-use transaction::OutPoint;
+use crate::transaction::OutPoint;
 
 /// The zero hash.
 const ZERO32: [u8; 32] = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,15 @@ mod endian;
 // re-export bitcoin deps which we re-use
 pub use bitcoin::{bech32, hashes};
 // export everything at the top level so it can be used as `elements::Transaction` etc.
-pub use address::{Address, AddressParams, AddressError};
-pub use transaction::{OutPoint, PeginData, PegoutData, EcdsaSigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};
-pub use blind::{ConfidentialTxOutError, TxOutSecrets, TxOutError, VerificationError, BlindError, UnblindError};
-pub use block::{BlockHeader, Block};
-pub use block::ExtData as BlockExtData;
+pub use crate::address::{Address, AddressParams, AddressError};
+pub use crate::transaction::{OutPoint, PeginData, PegoutData, EcdsaSigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};
+pub use crate::blind::{ConfidentialTxOutError, TxOutSecrets, TxOutError, VerificationError, BlindError, UnblindError};
+pub use crate::block::{BlockHeader, Block};
+pub use crate::block::ExtData as BlockExtData;
 pub use ::bitcoin::consensus::encode::VarInt;
-pub use fast_merkle_root::fast_merkle_root;
-pub use hash_types::*;
-pub use issuance::{AssetId, ContractHash};
-pub use script::Script;
-pub use sighash::SchnorrSigHashType;
-pub use schnorr::{SchnorrSig, SchnorrSigError};
+pub use crate::fast_merkle_root::fast_merkle_root;
+pub use crate::hash_types::*;
+pub use crate::issuance::{AssetId, ContractHash};
+pub use crate::script::Script;
+pub use crate::sighash::SchnorrSigHashType;
+pub use crate::schnorr::{SchnorrSig, SchnorrSigError};

--- a/src/pset/error.rs
+++ b/src/pset/error.rs
@@ -14,13 +14,13 @@
 
 use std::{error, fmt};
 
-use Txid;
-use encode;
+use crate::Txid;
+use crate::encode;
 
 use super::raw;
 
-use hashes;
-use blind::ConfidentialTxOutError;
+use crate::hashes;
+use crate::blind::ConfidentialTxOutError;
 use secp256k1_zkp;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/src/pset/map/global.rs
+++ b/src/pset/map/global.rs
@@ -17,12 +17,12 @@ use std::{collections::BTreeMap, io::{self, Cursor, Read}};
 use std::collections::btree_map::Entry;
 use std::cmp;
 
-use VarInt;
-use encode::{Decodable};
-use pset::{self, map::Map, raw, Error};
-use endian::u32_to_array_le;
+use crate::VarInt;
+use crate::encode::{Decodable};
+use crate::pset::{self, map::Map, raw, Error};
+use crate::endian::u32_to_array_le;
 use bitcoin::util::bip32::{ExtendedPubKey, KeySource, Fingerprint, DerivationPath, ChildNumber};
-use encode;
+use crate::encode;
 use secp256k1_zkp::Tweak;
 
 // (Not used in pset) Type: Unsigned Transaction PSET_GLOBAL_UNSIGNED_TX = 0x00
@@ -107,10 +107,10 @@ pub struct Global {
     /// Elements tx modifiable flag
     pub elements_tx_modifiable_flag: Option<u8>,
     /// Other Proprietary fields
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
     /// Unknown global key-value pairs.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }
 
@@ -466,7 +466,7 @@ impl Decodable for Global {
                         }
                     }
                 }
-                Err(::encode::Error::PsetError(::pset::Error::NoMorePairs)) => break,
+                Err(crate::encode::Error::PsetError(crate::pset::Error::NoMorePairs)) => break,
                 Err(e) => return Err(e),
             }
         }

--- a/src/pset/map/mod.rs
+++ b/src/pset/map/mod.rs
@@ -12,8 +12,8 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use encode;
-use pset::{self, raw};
+use crate::encode;
+use crate::pset::{self, raw};
 
 /// A trait that describes a PSET key-value map.
 pub(crate) trait Map {

--- a/src/pset/map/output.rs
+++ b/src/pset/map/output.rs
@@ -15,23 +15,23 @@
 use std::{collections::BTreeMap, io};
 use std::collections::btree_map::Entry;
 
-use taproot::TapLeafHash;
-use taproot::{NodeInfo, TaprootBuilder};
+use crate::taproot::TapLeafHash;
+use crate::taproot::{NodeInfo, TaprootBuilder};
 
-use {Script, encode, TxOutWitness};
+use crate::{Script, encode, TxOutWitness};
 use bitcoin::util::bip32::KeySource;
 use bitcoin::{self, PublicKey};
-use {pset, confidential};
-use encode::Decodable;
-use pset::map::Map;
-use pset::raw;
-use pset::Error;
+use crate::{pset, confidential};
+use crate::encode::Decodable;
+use crate::pset::map::Map;
+use crate::pset::raw;
+use crate::pset::Error;
 use secp256k1_zkp::{self, Generator, RangeProof, SurjectionProof};
 
-use issuance;
+use crate::issuance;
 
-use TxOut;
-use AssetId;
+use crate::TxOut;
+use crate::AssetId;
 
 /// Type: Redeem Script PSET_OUT_REDEEM_SCRIPT = 0x00
 const PSET_OUT_REDEEM_SCRIPT: u8 = 0x00;
@@ -95,14 +95,14 @@ pub struct Output {
     pub witness_script: Option<Script>,
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub bip32_derivation: BTreeMap<PublicKey, KeySource>,
     /// The internal pubkey
     pub tap_internal_key: Option<bitcoin::XOnlyPublicKey>,
     /// Taproot Output tree
     pub tap_tree: Option<TapTree>,
     /// Map of tap root x only keys to origin info and leaf hashes contained in it
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub tap_key_origins: BTreeMap<bitcoin::XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
     /// (PSET) The explicit amount of the output
     pub amount: Option<u64>,
@@ -131,10 +131,10 @@ pub struct Output {
     pub blind_asset_proof: Option<Box<SurjectionProof>>,
     /// Pset
     /// Other fields
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
     /// Unknown key-value pairs for this output.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }
 
@@ -539,7 +539,7 @@ impl Decodable for Output {
                         _ =>  rv.insert_pair(raw::Pair { key: raw_key, value: raw_value })?,
                     }
                 }
-                Err(::encode::Error::PsetError(::pset::Error::NoMorePairs)) => break,
+                Err(crate::encode::Error::PsetError(crate::pset::Error::NoMorePairs)) => break,
                 Err(e) => return Err(e),
             }
         }

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -29,17 +29,17 @@ mod map;
 pub mod raw;
 pub mod serialize;
 
-use {Transaction, Txid, TxIn, OutPoint, TxInWitness, TxOut, TxOutWitness};
-use encode::{self, Encodable, Decodable};
-use confidential;
+use crate::{Transaction, Txid, TxIn, OutPoint, TxInWitness, TxOut, TxOutWitness};
+use crate::encode::{self, Encodable, Decodable};
+use crate::confidential;
 use secp256k1_zkp::rand::{CryptoRng, RngCore};
 use secp256k1_zkp::{self, RangeProof, SurjectionProof};
-use {TxOutSecrets, blind::RangeProofMessage, confidential::{AssetBlindingFactor, ValueBlindingFactor}};
+use crate::{TxOutSecrets, blind::RangeProofMessage, confidential::{AssetBlindingFactor, ValueBlindingFactor}};
 use bitcoin;
 
-use blind::ConfidentialTxOutError;
+use crate::blind::ConfidentialTxOutError;
 
-use blind::{BlindAssetProofs, BlindValueProofs};
+use crate::blind::{BlindAssetProofs, BlindValueProofs};
 
 pub use self::error::{Error, PsetBlindError};
 pub use self::map::{Global, GlobalTxData, Input, Output, TapTree};
@@ -728,7 +728,7 @@ mod tests {
         use std::str::FromStr;
         use rand::{self, SeedableRng};
         use serde_json;
-        use AssetId;
+        use crate::AssetId;
 
         // Initially secp context and rng global state
         let secp = secp256k1_zkp::Secp256k1::new();

--- a/src/pset/raw.rs
+++ b/src/pset/raw.rs
@@ -19,10 +19,10 @@
 
 use std::{fmt, io};
 
-use encode::{self, Decodable, Encodable, ReadExt, WriteExt, serialize, deserialize, MAX_VEC_SIZE};
-use hashes::hex;
+use crate::encode::{self, Decodable, Encodable, ReadExt, WriteExt, serialize, deserialize, MAX_VEC_SIZE};
+use crate::hashes::hex;
 use super::Error;
-use VarInt;
+use crate::VarInt;
 /// A PSET key in its raw byte form.
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -30,7 +30,7 @@ pub struct Key {
     /// The type of this PSET key.
     pub type_value: u8,
     /// The key itself in raw byte form.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub key: Vec<u8>,
 }
 
@@ -53,7 +53,7 @@ pub struct Pair {
     /// The key of this key-value pair.
     pub key: Key,
     /// The value of this key-value pair in raw byte form.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub value: Vec<u8>,
 }
 
@@ -67,12 +67,12 @@ pub type ProprietaryType = u8;
 pub struct ProprietaryKey<Subtype = ProprietaryType> where Subtype: Copy + From<u8> + Into<u8> {
     /// Proprietary type prefix used for grouping together keys under some
     /// application and avoid namespace collision
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub prefix: Vec<u8>,
     /// Custom proprietary subtype
     pub subtype: Subtype,
     /// Additional key bytes (like serialized public key data etc)
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub key: Vec<u8>,
 }
 

--- a/src/pset/serialize.rs
+++ b/src/pset/serialize.rs
@@ -20,20 +20,20 @@
 use std::io;
 
 use bitcoin::{self, PublicKey, VarInt};
-use {Script, Transaction, TxOut, Txid, BlockHash, AssetId};
-use encode::{self, serialize, deserialize, Decodable, Encodable, deserialize_partial};
+use crate::{Script, Transaction, TxOut, Txid, BlockHash, AssetId};
+use crate::encode::{self, serialize, deserialize, Decodable, Encodable, deserialize_partial};
 use bitcoin::util::bip32::{ChildNumber, Fingerprint, KeySource};
-use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use crate::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use bitcoin::hashes::hex::ToHex;
-use confidential;
+use crate::confidential;
 use secp256k1_zkp::{self, RangeProof, SurjectionProof, Tweak};
 
-use taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
-use schnorr;
+use crate::taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
+use crate::schnorr;
 use super::map::{TapTree, PsbtSighashType};
 
-use taproot::TaprootBuilder;
-use sighash::SchnorrSigHashType;
+use crate::taproot::TaprootBuilder;
+use crate::sighash::SchnorrSigHashType;
 
 /// A trait for serializing a value as raw data for insertion into PSET
 /// key-value pairs.

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -21,9 +21,9 @@ use std::fmt;
 
 pub use secp256k1_zkp::{XOnlyPublicKey, KeyPair};
 use secp256k1_zkp::{self, Secp256k1, Verification, constants::SCHNORR_SIGNATURE_SIZE};
-use hashes::{Hash, HashEngine};
-use taproot::{TapBranchHash, TapTweakHash};
-use SchnorrSigHashType;
+use crate::hashes::{Hash, HashEngine};
+use crate::taproot::{TapBranchHash, TapTweakHash};
+use crate::SchnorrSigHashType;
 
 /// Untweaked Schnorr public key
 pub type UntweakedPublicKey = XOnlyPublicKey;

--- a/src/script.rs
+++ b/src/script.rs
@@ -30,14 +30,14 @@ use std::{fmt, io, ops, str};
 use secp256k1_zkp::{Verification, Secp256k1};
 #[cfg(feature = "serde")] use serde;
 
-use encode::{self, Decodable, Encodable};
+use crate::encode::{self, Decodable, Encodable};
 use bitcoin::hashes::{Hash, hex};
-use {opcodes, ScriptHash, WScriptHash, PubkeyHash, WPubkeyHash};
+use crate::{opcodes, ScriptHash, WScriptHash, PubkeyHash, WPubkeyHash};
 
 use bitcoin::PublicKey;
 
-use schnorr::{UntweakedPublicKey, TweakedPublicKey, TapTweak};
-use taproot::TapBranchHash;
+use crate::schnorr::{UntweakedPublicKey, TweakedPublicKey, TapTweak};
+use crate::taproot::TapBranchHash;
 
 const MAX_SCRIPT_SIZE : usize = 10_000;
 
@@ -261,29 +261,29 @@ impl Script {
 
     /// Generates P2WPKH-type of scriptPubkey
     pub fn new_v0_wpkh(pubkey_hash: &WPubkeyHash) -> Script {
-        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &pubkey_hash.to_vec())
+        Script::new_witness_program(crate::bech32::u5::try_from_u8(0).unwrap(), &pubkey_hash.to_vec())
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
     pub fn new_v0_wsh(script_hash: &WScriptHash) -> Script {
-        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &script_hash.to_vec())
+        Script::new_witness_program(crate::bech32::u5::try_from_u8(0).unwrap(), &script_hash.to_vec())
     }
 
     /// Generates P2TR for script spending path using an internal public key and some optional
     /// script tree merkle root.
     pub fn new_v1_p2tr<C: Verification>(secp: &Secp256k1<C>, internal_key: UntweakedPublicKey, merkle_root: Option<TapBranchHash>) -> Script {
         let (output_key, _) = internal_key.tap_tweak(secp, merkle_root);
-        Script::new_witness_program(::bech32::u5::try_from_u8(1).unwrap(), &output_key.as_inner().serialize())
+        Script::new_witness_program(crate::bech32::u5::try_from_u8(1).unwrap(), &output_key.as_inner().serialize())
     }
 
     /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
     pub fn new_v1_p2tr_tweaked(output_key: TweakedPublicKey) -> Script {
-        Script::new_witness_program(::bech32::u5::try_from_u8(1).unwrap(), &output_key.as_inner().serialize())
+        Script::new_witness_program(crate::bech32::u5::try_from_u8(1).unwrap(), &output_key.as_inner().serialize())
     }
 
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
-    pub fn new_witness_program(ver: ::bech32::u5, program: &[u8]) -> Script {
+    pub fn new_witness_program(ver: crate::bech32::u5, program: &[u8]) -> Script {
         let mut verop = ver.to_u8();
         assert!(verop <= 16, "incorrect witness version provided: {}", verop);
         if verop > 0 {
@@ -920,8 +920,8 @@ mod test {
     use super::*;
     use super::build_scriptint;
 
-    use encode::{deserialize, serialize};
-    use opcodes;
+    use crate::encode::{deserialize, serialize};
+    use crate::opcodes;
 
     #[test]
     fn script() {

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -7,7 +7,7 @@ pub mod btreemap_byte_values {
     // NOTE: This module can be exactly copied to use with HashMap.
 
     use ::std::collections::BTreeMap;
-    use hashes::hex::{FromHex, ToHex};
+    use bitcoin::hashes::hex::{FromHex, ToHex};
     use serde;
 
     pub fn serialize<S, T>(v: &BTreeMap<T, Vec<u8>>, s: S)
@@ -149,7 +149,7 @@ pub mod btreemap_as_seq_byte_values {
     #[derive(Debug, Deserialize)]
     struct OwnedPair<T>(
         T,
-        #[serde(deserialize_with = "::serde_utils::hex_bytes::deserialize")]
+        #[serde(deserialize_with = "crate::serde_utils::hex_bytes::deserialize")]
         Vec<u8>,
     );
 
@@ -157,7 +157,7 @@ pub mod btreemap_as_seq_byte_values {
     #[derive(Debug, Serialize)]
     struct BorrowedPair<'a, T: 'static>(
         &'a T,
-        #[serde(serialize_with = "::serde_utils::hex_bytes::serialize")]
+        #[serde(serialize_with = "crate::serde_utils::hex_bytes::serialize")]
         &'a [u8],
     );
 
@@ -221,7 +221,7 @@ pub mod hex_bytes {
     //! Module for serialization of byte arrays as hex strings.
     #![allow(missing_docs)]
 
-    use hashes::hex::{FromHex, ToHex};
+    use bitcoin::hashes::hex::{FromHex, ToHex};
     use serde;
 
     pub fn serialize<T, S>(bytes: &T, s: S) -> Result<S::Ok, S::Error>

--- a/src/sighash.rs
+++ b/src/sighash.rs
@@ -19,21 +19,21 @@
 //! signatures, which are placed in the scriptSig.
 //!
 
-use encode::{self, Encodable};
-use hash_types::SigHash;
-use hashes::{sha256d, Hash, sha256};
-use script::Script;
+use crate::encode::{self, Encodable};
+use crate::hash_types::SigHash;
+use crate::hashes::{sha256d, Hash, sha256};
+use crate::script::Script;
 use std::ops::{Deref, DerefMut};
 use std::io;
-use endian;
-use transaction::{EcdsaSigHashType, Transaction, TxIn, TxOut, TxInWitness};
-use confidential;
+use crate::endian;
+use crate::transaction::{EcdsaSigHashType, Transaction, TxIn, TxOut, TxInWitness};
+use crate::confidential;
 use std::fmt;
-use taproot::{TapSighashHash, TapLeafHash};
+use crate::taproot::{TapSighashHash, TapLeafHash};
 
-use BlockHash;
+use crate::BlockHash;
 
-use transaction::SighashTypeParseError;
+use crate::transaction::SighashTypeParseError;
 /// Efficiently calculates signature hash message for legacy, segwit and taproot inputs.
 #[derive(Debug)]
 pub struct SigHashCache<T: Deref<Target = Transaction>> {
@@ -963,7 +963,7 @@ impl std::str::FromStr for SchnorrSigHashType {
 #[cfg(test)]
 mod tests{
     use super::*;
-    use encode::deserialize;
+    use crate::encode::deserialize;
     use bitcoin::hashes::hex::FromHex;
     use bitcoin;
 

--- a/src/slip77.rs
+++ b/src/slip77.rs
@@ -7,7 +7,7 @@ use bitcoin::hashes::{Hash, HashEngine, hmac, sha256, sha256d};
 use secp256k1_zkp;
 use slip21;
 
-use Script;
+use crate::Script;
 
 const SLIP77_DERIVATION: &str = "SLIP-0077";
 
@@ -55,7 +55,7 @@ mod tests {
     use secp256k1_zkp::SecretKey;
     use bitcoin::hashes::hex::FromHex;
 
-    use address::Address;
+    use crate::address::Address;
 
     #[test]
     fn test_slip77() {

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -16,13 +16,13 @@
 use std::cmp::Reverse;
 use std::{error, io, fmt};
 
-use hashes::{sha256, sha256t, Hash};
-use schnorr::{UntweakedPublicKey, TweakedPublicKey, TapTweak};
-use Script;
+use crate::hashes::{sha256, sha256t, Hash};
+use crate::schnorr::{UntweakedPublicKey, TweakedPublicKey, TapTweak};
+use crate::Script;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use secp256k1_zkp::{self, Secp256k1};
-use hashes::HashEngine;
-use encode::Encodable;
+use crate::hashes::HashEngine;
+use crate::encode::Encodable;
 
 /// The SHA-256 midstate value for the TapLeaf/elements hash.
 const MIDSTATE_TAPLEAF: [u8; 32] = [
@@ -888,9 +888,9 @@ impl error::Error for TaprootError {}
 #[cfg(test)]
 mod tests{
     use super::*;
-    use hashes::HashEngine;
-    use hashes::sha256t::Tag;
-    use hashes::hex::FromHex;
+    use crate::hashes::HashEngine;
+    use crate::hashes::sha256t::Tag;
+    use crate::hashes::hex::FromHex;
     use std::str::FromStr;
 
     fn tag_engine(tag_name: &str) -> sha256::HashEngine {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -21,12 +21,12 @@ use std::collections::HashMap;
 use bitcoin::{self, VarInt};
 use bitcoin::hashes::Hash;
 
-use confidential;
-use encode::{self, Encodable, Decodable};
-use issuance::AssetId;
-use opcodes;
-use script::Instruction;
-use {Script, Txid, Wtxid};
+use crate::confidential;
+use crate::encode::{self, Encodable, Decodable};
+use crate::issuance::AssetId;
+use crate::opcodes;
+use crate::script::Instruction;
+use crate::{Script, Txid, Wtxid};
 use secp256k1_zkp::{
     RangeProof, SurjectionProof, Tweak,
 };
@@ -939,10 +939,10 @@ mod tests {
     use bitcoin;
     use bitcoin::hashes::hex::FromHex;
 
-    use encode::serialize;
-    use confidential;
+    use crate::encode::serialize;
+    use crate::confidential;
     use secp256k1_zkp::{self, ZERO_TWEAK};
-    use script;
+    use crate::script;
 
     use super::*;
 


### PR DESCRIPTION
Fixes #132 

I went through the steps [to transition to a new edition](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html)

The only fixes necessary were removing `$crate::` in the trait bounds of `impl_consensus_encoding` macro, and then fixing a few issues that didn't appear with default features.