### PR TITLE
dynafed: Change fedpegprogram back to bitcoin::Script

### DIFF
--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -46,7 +46,7 @@ pub enum Params {
         /// Maximum, in bytes, of the size of a blocksigning witness
         signblock_witness_limit: u32,
         /// Untweaked `scriptPubKey` used for pegins
-        fedpeg_program: Script,
+        fedpeg_program: bitcoin::Script,
         /// For v0 fedpeg programs, the witness script of the untweaked
         /// pegin address. For future versions, this data has no defined
         /// meaning and will be considered "anyone can spend".
@@ -158,7 +158,7 @@ impl Params {
     }
 
     /// Get the fedpeg_program. Is [None] for non-[Full] params.
-    pub fn fedpeg_program(&self) -> Option<&Script> {
+    pub fn fedpeg_program(&self) -> Option<&bitcoin::Script> {
         match *self {
             Params::Null => None,
             Params::Compact { .. } => None,
@@ -623,7 +623,7 @@ mod tests {
 
         let signblockscript: Script = vec![1].into();
         let signblock_wl = 2;
-        let fp_program: Script = vec![3].into();
+        let fp_program: bitcoin::Script = vec![3].into();
         let fp_script = vec![4];
         let ext = vec![vec![5, 6], vec![7]];
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -233,6 +233,8 @@ impl_upstream!(btcenc::VarInt);
 impl_upstream!(::hashes::sha256d::Hash);
 impl_upstream!(bitcoin::Transaction);
 impl_upstream!(bitcoin::BlockHash);
+impl_upstream!(bitcoin::Script);
+
 
 // Vectors
 macro_rules! impl_vec {


### PR DESCRIPTION
This field refers to a script on the main chain.