### PR TITLE
Export Blind*Proofs traits

### DIFF
--- a/src/blind.rs
+++ b/src/blind.rs
@@ -869,6 +869,7 @@ impl From<ConfidentialTxOutError> for BlindError {
     }
 }
 
+/// A trait to create and verify explicit rangeproofs
 pub trait BlindValueProofs: Sized {
     /// Outputs a `[RangeProof]` that blinded value
     /// corresponfs to unblinded explicit value
@@ -939,6 +940,7 @@ impl BlindValueProofs for RangeProof {
     }
 }
 
+/// A trait to create and verify explicit surjection proofs
 pub trait BlindAssetProofs: Sized {
     /// Outputs a `[SurjectionProof]` that blinded asset
     /// corresponfs to unblinded explicit asset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use bitcoin::{bech32, hashes};
 // export everything at the top level so it can be used as `elements::Transaction` etc.
 pub use crate::address::{Address, AddressParams, AddressError};
 pub use crate::transaction::{OutPoint, PeginData, PegoutData, EcdsaSigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};
-pub use crate::blind::{ConfidentialTxOutError, TxOutSecrets, TxOutError, VerificationError, BlindError, UnblindError};
+pub use crate::blind::{ConfidentialTxOutError, TxOutSecrets, TxOutError, VerificationError, BlindError, UnblindError, BlindValueProofs, BlindAssetProofs};
 pub use crate::block::{BlockHeader, Block};
 pub use crate::block::ExtData as BlockExtData;
 pub use ::bitcoin::consensus::encode::VarInt;


### PR DESCRIPTION
So that the traits methods can be used downstream.