### PR TITLE
Introduce Sequence and LockTime from rust-bitcoin

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -61,6 +61,8 @@ pub enum Error {
     PsetError(pset::Error),
     /// Hex parsing errors
     HexError(hashes::hex::Error),
+    /// Got a time-based locktime when expecting a height-based one, or vice-versa
+    BadLockTime(crate::LockTime)
 }
 
 impl fmt::Display for Error {
@@ -81,6 +83,7 @@ impl fmt::Display for Error {
             Error::Secp256k1zkp(ref e) => write!(f, "{}", e),
             Error::PsetError(ref e) => write!(f, "Pset Error: {}", e),
             Error::HexError(ref e) => write!(f, "Hex error {}", e),
+            Error::BadLockTime(ref lt) => write!(f, "Invalid locktime {}", lt),
         }
     }
 }
@@ -223,6 +226,9 @@ macro_rules! impl_upstream {
 impl_upstream!(u8);
 impl_upstream!(u32);
 impl_upstream!(u64);
+impl_upstream!(crate::PackedLockTime);
+impl_upstream!(crate::LockTime);
+impl_upstream!(crate::Sequence);
 impl_upstream!([u8; 4]);
 impl_upstream!([u8; 32]);
 impl_upstream!(Box<[u8]>);
@@ -234,6 +240,36 @@ impl_upstream!(crate::hashes::sha256d::Hash);
 impl_upstream!(bitcoin::Transaction);
 impl_upstream!(bitcoin::BlockHash);
 impl_upstream!(bitcoin::Script);
+
+// Specific locktime types (which appear in PSET/PSBT2 but not in rust-bitcoin PSBT)
+impl Encodable for crate::locktime::Height {
+    fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, Error> {
+        crate::LockTime::from(*self).consensus_encode(s)
+    }
+}
+impl Decodable for crate::locktime::Height {
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, Error> {
+        match crate::LockTime::consensus_decode(d)? {
+            crate::LockTime::Blocks(h) => Ok(h),
+            x @ crate::LockTime::Seconds(_) => Err(Error::BadLockTime(x)),
+        }
+    }
+}
+
+
+impl Encodable for crate::locktime::Time {
+    fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, Error> {
+        crate::LockTime::from(*self).consensus_encode(s)
+    }
+}
+impl Decodable for crate::locktime::Time {
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, Error> {
+        match crate::LockTime::consensus_decode(d)? {
+            crate::LockTime::Seconds(t) => Ok(t),
+            x @ crate::LockTime::Blocks(_) => Err(Error::BadLockTime(x)),
+        }
+    }
+}
 
 
 // Vectors

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -226,9 +226,6 @@ macro_rules! impl_upstream {
 impl_upstream!(u8);
 impl_upstream!(u32);
 impl_upstream!(u64);
-impl_upstream!(crate::PackedLockTime);
-impl_upstream!(crate::LockTime);
-impl_upstream!(crate::Sequence);
 impl_upstream!([u8; 4]);
 impl_upstream!([u8; 32]);
 impl_upstream!(Box<[u8]>);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,47 @@
+//! Contains error types and other error handling tools.
+
+pub use crate::parse::ParseIntError;
+
+/// Impls std::error::Error for the specified type with appropriate attributes, possibly returning
+/// source.
+macro_rules! impl_std_error {
+    // No source available
+    ($type:ty) => {
+        #[cfg(feature = "std")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+        impl std::error::Error for $type {}
+    };
+    // Struct with $field as source
+    ($type:ty, $field:ident) => {
+        #[cfg(feature = "std")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+        impl std::error::Error for $type {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.$field)
+            }
+        }
+    };
+}
+pub(crate) use impl_std_error;
+
+/// Formats error. If `std` feature is OFF appends error source (delimited by `: `). We do this
+/// because `e.source()` is only available in std builds, without this macro the error source is
+/// lost for no-std builds.
+macro_rules! write_err {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        {   
+            #[cfg(feature = "std")]
+            {   
+                let _ = &$source;   // Prevents clippy warnings.
+                write!($writer, $string $(, $args)*)
+            }   
+            #[cfg(not(feature = "std"))]
+            {   
+                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
+            }   
+        }   
+    }   
+}
+pub(crate) use write_err;
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,16 @@ mod block;
 pub mod confidential;
 pub mod dynafed;
 pub mod encode;
+mod error;
 mod fast_merkle_root;
 pub mod hash_types;
+pub mod locktime;
 pub mod issuance;
 pub mod opcodes;
 pub mod script;
 mod transaction;
 mod blind;
+mod parse;
 pub mod slip77;
 pub mod sighash;
 pub mod pset;
@@ -62,12 +65,10 @@ mod serde_utils;
 mod endian;
 // re-export bitcoin deps which we re-use
 pub use bitcoin::{bech32, hashes};
-// re-export bitcoin locktime types, which have identical semantics as in Elements,
-//  and differ only by what kind of transaction they appear in.
-pub use bitcoin::{blockdata::locktime, LockTime, PackedLockTime, Sequence};
 // export everything at the top level so it can be used as `elements::Transaction` etc.
 pub use crate::address::{Address, AddressParams, AddressError};
 pub use crate::transaction::{OutPoint, PeginData, PegoutData, EcdsaSigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};
+pub use crate::transaction::Sequence;
 pub use crate::blind::{ConfidentialTxOutError, TxOutSecrets, SurjectionInput, TxOutError, VerificationError, BlindError, UnblindError, BlindValueProofs, BlindAssetProofs};
 pub use crate::block::{BlockHeader, Block};
 pub use crate::block::ExtData as BlockExtData;
@@ -75,6 +76,7 @@ pub use ::bitcoin::consensus::encode::VarInt;
 pub use crate::fast_merkle_root::fast_merkle_root;
 pub use crate::hash_types::*;
 pub use crate::issuance::{AssetId, ContractHash};
+pub use crate::locktime::{LockTime, PackedLockTime};
 pub use crate::script::Script;
 pub use crate::sighash::SchnorrSigHashType;
 pub use crate::schnorr::{SchnorrSig, SchnorrSigError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ mod serde_utils;
 mod endian;
 // re-export bitcoin deps which we re-use
 pub use bitcoin::{bech32, hashes};
+// re-export bitcoin locktime types, which have identical semantics as in Elements,
+//  and differ only by what kind of transaction they appear in.
+pub use bitcoin::{blockdata::locktime, LockTime, PackedLockTime, Sequence};
 // export everything at the top level so it can be used as `elements::Transaction` etc.
 pub use crate::address::{Address, AddressParams, AddressError};
 pub use crate::transaction::{OutPoint, PeginData, PegoutData, EcdsaSigHashType, TxIn, TxOut, TxInWitness, TxOutWitness, Transaction, AssetIssuance};

--- a/src/locktime.rs
+++ b/src/locktime.rs
@@ -1,0 +1,727 @@
+// Rust Bitcoin Library
+// Written in 2022 by
+//     Tobin C. Harding <me@tobin.cc>
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Provides type [`LockTime`] that implements the logic around nLockTime/OP_CHECKLOCKTIMEVERIFY.
+//!
+//! There are two types of lock time: lock-by-blockheight and lock-by-blocktime, distinguished by
+//! whether `LockTime < LOCKTIME_THRESHOLD`.
+//!
+
+use std::{mem, fmt};
+use std::cmp::{PartialOrd, Ordering};
+use std::convert::TryFrom;
+use std::str::FromStr;
+use std::io::{Read, Write};
+use crate::error::ParseIntError;
+use crate::parse;
+
+use crate::encode::{self, Decodable, Encodable};
+use crate::error::write_err;
+use crate::parse::impl_parse_str_through_int;
+
+/// The Threshold for deciding whether a lock time value is a height or a time (see [Bitcoin Core]).
+///
+/// `LockTime` values _below_ the threshold are interpreted as block heights, values _above_ (or
+/// equal to) the threshold are interpreted as block times (UNIX timestamp, seconds since epoch).
+///
+/// Bitcoin is able to safely use this value because a block height greater than 500,000,000 would
+/// never occur because it would represent a height in approximately 9500 years. Conversely, block
+/// times under 500,000,000 will never happen because they would represent times before 1986 which
+/// are, for obvious reasons, not useful within the Bitcoin network.
+///
+/// [Bitcoin Core]: https://github.com/bitcoin/bitcoin/blob/9ccaee1d5e2e4b79b0a7c29aadb41b97e4741332/src/script/script.h#L39
+pub const LOCK_TIME_THRESHOLD: u32 = 500_000_000;
+
+/// Packed lock time wraps a [`LockTime`] consensus value i.e., the raw `u32` used by the network.
+///
+/// This struct may be preferred in performance-critical applications because it's slightly smaller
+/// than [`LockTime`] and has a bit more performant (de)serialization. In particular, this may be
+/// relevant when the value is not processed, just passed around. Note however that the difference
+/// is super-small, so unless you do something extreme you shouldn't worry about it.
+///
+/// This type implements a naive ordering based on the `u32`, this is _not_ a semantically correct
+/// ordering for a lock time, hence [`LockTime`] does not implement `Ord`. This type is useful if
+/// you want to use a lock time as part of a struct and wish to derive `Ord`. For all other uses,
+/// consider using [`LockTime`] directly.
+///
+/// # Examples
+/// ```
+/// # use bitcoin::{Amount, PackedLockTime, LockTime};
+/// #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+/// struct S {
+///     lock_time: PackedLockTime,
+///     amount: Amount,
+/// }
+///
+/// let _ = S {
+///     lock_time: LockTime::from_consensus(741521).into(),
+///     amount: Amount::from_sat(10_000_000),
+/// };
+/// ```
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct PackedLockTime(pub u32);
+
+impl PackedLockTime {
+    /// If [`crate::Transaction::lock_time`] is set to zero it is ignored, in other words a
+    /// transaction with nLocktime==0 is able to be included immediately in any block.
+    pub const ZERO: PackedLockTime = PackedLockTime(0);
+
+    /// Returns the inner `u32`.
+    #[inline]
+    pub fn to_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for PackedLockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl Encodable for PackedLockTime {
+    #[inline]
+    fn consensus_encode<W: Write>(&self, w: W) -> Result<usize, encode::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for PackedLockTime {
+    #[inline]
+    fn consensus_decode<R: Read>(r: R) -> Result<Self, encode::Error> {
+        u32::consensus_decode(r).map(PackedLockTime)
+    }
+}
+
+impl From<LockTime> for PackedLockTime {
+    fn from(n: LockTime) -> Self {
+        PackedLockTime(n.to_consensus_u32())
+    }
+}
+
+impl From<PackedLockTime> for LockTime {
+    fn from(n: PackedLockTime) -> Self {
+        LockTime::from_consensus(n.0)
+    }
+}
+
+impl From<&LockTime> for PackedLockTime {
+    fn from(n: &LockTime) -> Self {
+        PackedLockTime(n.to_consensus_u32())
+    }
+}
+
+impl From<&PackedLockTime> for LockTime {
+    fn from(n: &PackedLockTime) -> Self {
+        LockTime::from_consensus(n.0)
+    }
+}
+
+impl From<PackedLockTime> for u32 {
+    fn from(p: PackedLockTime) -> Self {
+        p.0
+    }
+}
+
+impl_parse_str_through_int!(PackedLockTime);
+
+impl fmt::LowerHex for PackedLockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:x}", self.0)
+    }
+}
+
+impl fmt::UpperHex for PackedLockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:X}", self.0)
+    }
+}
+
+/// A lock time value, representing either a block height or a UNIX timestamp (seconds since epoch).
+///
+/// Used for transaction lock time (`nLockTime` in Bitcoin Core and [`crate::Transaction::lock_time`]
+/// in this library) and also for the argument to opcode 'OP_CHECKLOCKTIMEVERIFY`.
+///
+/// ### Relevant BIPs
+///
+/// * [BIP-65 OP_CHECKLOCKTIMEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
+/// * [BIP-113 Median time-past as endpoint for lock-time calculations](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)
+///
+/// # Examples
+/// ```
+/// # use bitcoin::{LockTime, LockTime::*};
+/// # let n = LockTime::from_consensus(100);          // n OP_CHECKLOCKTIMEVERIFY
+/// # let lock_time = LockTime::from_consensus(100);  // nLockTime
+/// // To compare lock times there are various `is_satisfied_*` methods, you may also use:
+/// let is_satisfied = match (n, lock_time) {
+///     (Blocks(n), Blocks(lock_time)) => n <= lock_time,
+///     (Seconds(n), Seconds(lock_time)) => n <= lock_time,
+///     _ => panic!("handle invalid comparison error"),
+/// };
+/// ```
+#[allow(clippy::derive_ord_xor_partial_ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub enum LockTime {
+    /// A block height lock time value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::LockTime;
+    ///
+    /// let block: u32 = 741521;
+    /// let n = LockTime::from_height(block).expect("valid height");
+    /// assert!(n.is_block_height());
+    /// assert_eq!(n.to_consensus_u32(), block);
+    /// ```
+    Blocks(Height),
+    /// A UNIX timestamp lock time value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::LockTime;
+    ///
+    /// let seconds: u32 = 1653195600; // May 22nd, 5am UTC.
+    /// let n = LockTime::from_time(seconds).expect("valid time");
+    /// assert!(n.is_block_time());
+    /// assert_eq!(n.to_consensus_u32(), seconds);
+    /// ```
+    Seconds(Time),
+}
+
+impl LockTime {
+    /// If [`crate::Transaction::lock_time`] is set to zero it is ignored, in other words a
+    /// transaction with nLocktime==0 is able to be included immediately in any block.
+    pub const ZERO: LockTime = LockTime::Blocks(Height(0));
+
+    /// Constructs a `LockTime` from an nLockTime value or the argument to OP_CHEKCLOCKTIMEVERIFY.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::LockTime;
+    /// # let n = LockTime::from_consensus(741521); // n OP_CHECKLOCKTIMEVERIFY
+    ///
+    /// // `from_consensus` roundtrips as expected with `to_consensus_u32`.
+    /// let n_lock_time: u32 = 741521;
+    /// let lock_time = LockTime::from_consensus(n_lock_time);
+    /// assert_eq!(lock_time.to_consensus_u32(), n_lock_time);
+    #[inline]
+    pub fn from_consensus(n: u32) -> Self {
+        if is_block_height(n) {
+            Self::Blocks(Height::from_consensus(n).expect("n is valid"))
+        } else {
+            Self::Seconds(Time::from_consensus(n).expect("n is valid"))
+        }
+    }
+
+    /// Constructs a `LockTime` from `n`, expecting `n` to be a valid block height.
+    ///
+    /// See [`LOCK_TIME_THRESHOLD`] for definition of a valid height value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use bitcoin::LockTime;
+    /// assert!(LockTime::from_height(741521).is_ok());
+    /// assert!(LockTime::from_height(1653195600).is_err());
+    /// ```
+    #[inline]
+    pub fn from_height(n: u32) -> Result<Self, Error> {
+        let height = Height::from_consensus(n)?;
+        Ok(LockTime::Blocks(height))
+    }
+
+    /// Constructs a `LockTime` from `n`, expecting `n` to be a valid block time.
+    ///
+    /// See [`LOCK_TIME_THRESHOLD`] for definition of a valid time value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use bitcoin::LockTime;
+    /// assert!(LockTime::from_time(1653195600).is_ok());
+    /// assert!(LockTime::from_time(741521).is_err());
+    /// ```
+    #[inline]
+    pub fn from_time(n: u32) -> Result<Self, Error> {
+        let time = Time::from_consensus(n)?;
+        Ok(LockTime::Seconds(time))
+    }
+
+    /// Returns true if both lock times use the same unit i.e., both height based or both time based.
+    #[inline]
+    pub fn is_same_unit(&self, other: LockTime) -> bool {
+        mem::discriminant(self) == mem::discriminant(&other)
+    }
+
+    /// Returns true if this lock time value is a block height.
+    #[inline]
+    pub fn is_block_height(&self) -> bool {
+        match *self {
+            LockTime::Blocks(_) => true,
+            LockTime::Seconds(_) => false,
+        }
+    }
+
+    /// Returns true if this lock time value is a block time (UNIX timestamp).
+    #[inline]
+    pub fn is_block_time(&self) -> bool {
+        !self.is_block_height()
+    }
+
+    /// Returns true if this timelock constraint is satisfied by the respective `height`/`time`.
+    ///
+    /// If `self` is a blockheight based lock then it is checked against `height` and if `self` is a
+    /// blocktime based lock it is checked against `time`.
+    ///
+    /// A 'timelock constraint' refers to the `n` from `n OP_CHEKCLOCKTIMEVERIFY`, this constraint
+    /// is satisfied if a transaction with nLockTime ([`crate::Transaction::lock_time`]) set to
+    /// `height`/`time` is valid.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use bitcoin::blockdata::locktime::{LockTime, Height, Time};
+    /// // Can be implemented if block chain data is available.
+    /// fn get_height() -> Height { todo!("return the current block height") }
+    /// fn get_time() -> Time { todo!("return the current block time") }
+    ///
+    /// let n = LockTime::from_consensus(741521); // `n OP_CHEKCLOCKTIMEVERIFY`.
+    /// if n.is_satisfied_by(get_height(), get_time()) {
+    ///     // Can create and mine a transaction that satisfies the OP_CLTV timelock constraint.
+    /// }
+    /// ````
+    #[inline]
+    pub fn is_satisfied_by(&self, height: Height, time: Time) -> bool {
+        use LockTime::*;
+
+        match *self {
+            Blocks(n) => n <= height,
+            Seconds(n) => n <= time,
+        }
+    }
+
+    /// Returns the inner `u32` value. This is the value used when creating this `LockTime`
+    /// i.e., `n OP_CHECKLOCKTIMEVERIFY` or nLockTime.
+    ///
+    /// # Warning
+    ///
+    /// Do not compare values return by this method. The whole point of the `LockTime` type is to
+    /// assist in doing correct comparisons. Either use `is_satisfied_by` or use the pattern below:
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bitcoin::{LockTime, LockTime::*};
+    /// # let n = LockTime::from_consensus(100);          // n OP_CHECKLOCKTIMEVERIFY
+    /// # let lock_time = LockTime::from_consensus(100);  // nLockTime
+    ///
+    /// let is_satisfied = match (n, lock_time) {
+    ///     (Blocks(n), Blocks(lock_time)) => n <= lock_time,
+    ///     (Seconds(n), Seconds(lock_time)) => n <= lock_time,
+    ///     _ => panic!("invalid comparison"),
+    /// };
+    ///
+    /// // Or, if you have Rust 1.53 or greater
+    /// // let is_satisfied = n.partial_cmp(&lock_time).expect("invalid comparison").is_le();
+    /// ```
+    #[inline]
+    pub fn to_consensus_u32(self) -> u32 {
+        match self {
+            LockTime::Blocks(ref h) => h.to_consensus_u32(),
+            LockTime::Seconds(ref t) => t.to_consensus_u32(),
+        }
+    }
+}
+
+impl_parse_str_through_int!(LockTime, from_consensus);
+
+impl From<Height> for LockTime {
+    fn from(h: Height) -> Self {
+        LockTime::Blocks(h)
+    }
+}
+
+impl From<Time> for LockTime {
+    fn from(t: Time) -> Self {
+        LockTime::Seconds(t)
+    }
+}
+
+impl PartialOrd for LockTime {
+    fn partial_cmp(&self, other: &LockTime) -> Option<Ordering> {
+        use LockTime::*;
+
+        match (*self, *other) {
+            (Blocks(ref a), Blocks(ref b)) => a.partial_cmp(b),
+            (Seconds(ref a), Seconds(ref b)) => a.partial_cmp(b),
+            (_, _) => None,
+        }
+    }
+}
+
+impl fmt::Display for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use LockTime::*;
+
+        if f.alternate() {
+            match *self {
+                Blocks(ref h) => write!(f, "block-height {}", h),
+                Seconds(ref t) => write!(f, "block-time {} (seconds since epoch)", t),
+            }
+        } else {
+            match *self {
+                Blocks(ref h) => fmt::Display::fmt(h, f),
+                Seconds(ref t) => fmt::Display::fmt(t, f),
+            }
+        }
+    }
+}
+
+impl Encodable for LockTime {
+    #[inline]
+    fn consensus_encode<W: Write>(&self, w: W) -> Result<usize, encode::Error> {
+        let v = self.to_consensus_u32();
+        v.consensus_encode(w)
+    }
+}
+
+impl Decodable for LockTime {
+    #[inline]
+    fn consensus_decode<R: Read>(r: R) -> Result<Self, encode::Error> {
+        u32::consensus_decode(r).map(LockTime::from_consensus)
+    }
+}
+
+/// An absolute block height, guaranteed to always contain a valid height value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Height(u32);
+
+impl Height {
+    /// Constructs a new block height.
+    ///
+    /// # Errors
+    ///
+    /// If `n` does not represent a block height value (see documentation on [`LockTime`]).
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::blockdata::locktime::Height;
+    ///
+    /// let h: u32 = 741521;
+    /// let height = Height::from_consensus(h).expect("invalid height value");
+    /// assert_eq!(height.to_consensus_u32(), h);
+    /// ```
+    #[inline]
+    pub fn from_consensus(n: u32) -> Result<Height, Error> {
+        if is_block_height(n) {
+            Ok(Self(n))
+        } else {
+            Err(ConversionError::invalid_height(n).into())
+        }
+    }
+
+    /// Converts this `Height` to its inner `u32` value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::LockTime;
+    ///
+    /// let n_lock_time: u32 = 741521;
+    /// let lock_time = LockTime::from_consensus(n_lock_time);
+    /// assert!(lock_time.is_block_height());
+    /// assert_eq!(lock_time.to_consensus_u32(), n_lock_time);
+    #[inline]
+    pub fn to_consensus_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for Height {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl FromStr for Height {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let n = parse::int(s)?;
+        Height::from_consensus(n)
+    }
+}
+
+impl TryFrom<&str> for Height {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let n = parse::int(s)?;
+        Height::from_consensus(n)
+    }
+}
+
+impl TryFrom<String> for Height {
+    type Error = Error;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let n = parse::int(s)?;
+        Height::from_consensus(n)
+    }
+}
+
+/// A UNIX timestamp, seconds since epoch, guaranteed to always contain a valid time value.
+///
+/// Note that there is no manipulation of the inner value during construction or when using
+/// `to_consensus_u32()`. Said another way, `Time(x)` means 'x seconds since epoch' _not_ '(x -
+/// threshold) seconds since epoch'.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Time(u32);
+
+impl Time {
+    /// Constructs a new block time.
+    ///
+    /// # Errors
+    ///
+    /// If `n` does not encode a UNIX time stamp (see documentation on [`LockTime`]).
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::blockdata::locktime::Time;
+    ///
+    /// let t: u32 = 1653195600; // May 22nd, 5am UTC.
+    /// let time = Time::from_consensus(t).expect("invalid time value");
+    /// assert_eq!(time.to_consensus_u32(), t);
+    /// ```
+    #[inline]
+    pub fn from_consensus(n: u32) -> Result<Time, Error> {
+        if is_block_time(n) {
+            Ok(Self(n))
+        } else {
+            Err(ConversionError::invalid_time(n).into())
+        }
+    }
+
+    /// Converts this `Time` to its inner `u32` value.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bitcoin::LockTime;
+    ///
+    /// let n_lock_time: u32 = 1653195600; // May 22nd, 5am UTC.
+    /// let lock_time = LockTime::from_consensus(n_lock_time);
+    /// assert_eq!(lock_time.to_consensus_u32(), n_lock_time);
+    /// ```
+    #[inline]
+    pub fn to_consensus_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for Time {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl FromStr for Time {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let n = parse::int(s)?;
+        Time::from_consensus(n)
+    }
+}
+
+impl TryFrom<&str> for Time {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let n = parse::int(s)?;
+        Time::from_consensus(n)
+    }
+}
+
+impl TryFrom<String> for Time {
+    type Error = Error;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let n = parse::int(s)?;
+        Time::from_consensus(n)
+    }
+}
+
+/// Returns true if `n` is a block height i.e., less than 500,000,000.
+fn is_block_height(n: u32) -> bool {
+    n < LOCK_TIME_THRESHOLD
+}
+
+/// Returns true if `n` is a UNIX timestamp i.e., greater than or equal to 500,000,000.
+fn is_block_time(n: u32) -> bool {
+    n >= LOCK_TIME_THRESHOLD
+}
+
+/// Catchall type for errors that relate to time locks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// An error occurred while converting a `u32` to a lock time variant.
+    Conversion(ConversionError),
+    /// An error occurred while operating on lock times.
+    Operation(OperationError),
+    /// An error occurred while parsing a string into an `u32`.
+    Parse(ParseIntError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        match *self {
+            Conversion(ref e) => write_err!(f, "error converting lock time value"; e),
+            Operation(ref e) => write_err!(f, "error during lock time operation"; e),
+            Parse(ref e) => write_err!(f, "failed to parse lock time from string"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match *self {
+            Conversion(ref e) => Some(e),
+            Operation(ref e) => Some(e),
+            Parse(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<ConversionError> for Error {
+    fn from(e: ConversionError) -> Self {
+        Error::Conversion(e)
+    }
+}
+
+impl From<OperationError> for Error {
+    fn from(e: OperationError) -> Self {
+        Error::Operation(e)
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(e: ParseIntError) -> Self {
+        Error::Parse(e)
+    }
+}
+
+/// An error that occurs when converting a `u32` to a lock time variant.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ConversionError {
+    /// The expected timelock unit, height (blocks) or time (seconds).
+    unit: LockTimeUnit,
+    /// The invalid input value.
+    input: u32,
+}
+
+impl ConversionError {
+    /// Constructs a `ConversionError` from an invalid `n` when expecting a height value.
+    fn invalid_height(n: u32) -> Self {
+        Self {
+            unit: LockTimeUnit::Blocks,
+            input: n,
+        }
+    }
+
+    /// Constructs a `ConversionError` from an invalid `n` when expecting a time value.
+    fn invalid_time(n: u32) -> Self {
+        Self {
+            unit: LockTimeUnit::Seconds,
+            input: n,
+        }
+    }
+}
+
+impl fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid lock time value {}, {}", self.input, self.unit)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for ConversionError {}
+
+/// Describes the two types of locking, lock-by-blockheight and lock-by-blocktime.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum LockTimeUnit {
+    /// Lock by blockheight.
+    Blocks,
+    /// Lock by blocktime.
+    Seconds,
+}
+
+impl fmt::Display for LockTimeUnit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use LockTimeUnit::*;
+
+        match *self {
+            Blocks => write!(f, "expected lock-by-blockheight (must be < {})", LOCK_TIME_THRESHOLD),
+            Seconds => write!(f, "expected lock-by-blocktime (must be >= {})", LOCK_TIME_THRESHOLD),
+        }
+    }
+}
+
+/// Errors than occur when operating on lock times.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum OperationError {
+    /// Cannot compare different lock time units (height vs time).
+    InvalidComparison,
+}
+
+impl fmt::Display for OperationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::OperationError::*;
+
+        match *self {
+            InvalidComparison => f.write_str("cannot compare different lock units (height vs time)"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for OperationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_and_alternate() {
+        let n = LockTime::from_consensus(100);
+        let s = format!("{}", n);
+        assert_eq!(&s, "100");
+
+        let got = format!("{:#}", n);
+        assert_eq!(got, "block-height 100");
+    }
+}

--- a/src/locktime.rs
+++ b/src/locktime.rs
@@ -34,10 +34,10 @@ use crate::parse::impl_parse_str_through_int;
 /// `LockTime` values _below_ the threshold are interpreted as block heights, values _above_ (or
 /// equal to) the threshold are interpreted as block times (UNIX timestamp, seconds since epoch).
 ///
-/// Bitcoin is able to safely use this value because a block height greater than 500,000,000 would
-/// never occur because it would represent a height in approximately 9500 years. Conversely, block
+/// Elements is able to safely use this value because a block height greater than 500,000,000 would
+/// never occur because it would represent a height in approximately 950 years. Conversely, block
 /// times under 500,000,000 will never happen because they would represent times before 1986 which
-/// are, for obvious reasons, not useful within the Bitcoin network.
+/// are, for obvious reasons, not useful within any Elements network.
 ///
 /// [Bitcoin Core]: https://github.com/bitcoin/bitcoin/blob/9ccaee1d5e2e4b79b0a7c29aadb41b97e4741332/src/script/script.h#L39
 pub const LOCK_TIME_THRESHOLD: u32 = 500_000_000;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,122 @@
+use crate::error::write_err;
+use crate::error::impl_std_error;
+use std::fmt;
+use std::str::FromStr;
+use std::convert::TryFrom;
+
+/// Error with rich context returned when a string can't be parsed as an integer.
+///
+/// This is an extension of [`std::num::ParseIntError`], which carries the input that failed to
+/// parse as well as type information. As a result it provides very informative error messages that
+/// make it easier to understand the problem and correct mistakes.
+///
+/// Note that this is larger than the type from `core` so if it's passed through a deep call stack
+/// in a performance-critical application you may want to box it or throw away the context by
+/// converting to `core` type.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ParseIntError {
+    input: String,
+    // for displaying - see Display impl with nice error message below
+    bits: u8,
+    // We could represent this as a single bit but it wouldn't actually derease the cost of moving
+    // the struct because String contains pointers so there will be padding of bits at least
+    // pointer_size - 1 bytes: min 1B in practice.
+    is_signed: bool,
+    source: std::num::ParseIntError,
+}
+
+impl ParseIntError {
+    /// Returns the input that was attempted to be parsed.
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+}
+
+impl From<ParseIntError> for std::num::ParseIntError {
+    fn from(value: ParseIntError) -> Self {
+        value.source
+    }
+}
+
+impl AsRef<std::num::ParseIntError> for ParseIntError {
+    fn as_ref(&self) -> &std::num::ParseIntError {
+        &self.source
+    }
+}
+
+impl fmt::Display for ParseIntError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let signed = if self.is_signed { "signed" } else { "unsigned" };
+        let n = if self.bits == 8 { "n" } else { "" };
+        write_err!(f, "failed to parse '{}' as a{} {}-bit {} integer", self.input, n, self.bits, signed; self.source)
+    }
+}
+
+/// Not strictly neccessary but serves as a lint - avoids weird behavior if someone accidentally
+/// passes non-integer to the `parse()` function.
+pub(crate) trait Integer: FromStr<Err=std::num::ParseIntError> + TryFrom<i8> + Sized {}
+
+macro_rules! impl_integer {
+    ($($type:ty),* $(,)?) => {
+        $(
+        impl Integer for $type {}
+        )*
+    }
+}
+
+impl_integer!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128);
+
+/// Parses the input string as an integer returning an error carrying rich context.
+///
+/// If the caller owns `String` or `Box<str>` which is not used later it's better to pass it as
+/// owned since it avoids allocation in error case.
+pub(crate) fn int<T: Integer, S: AsRef<str> + Into<String>>(s: S) -> Result<T, ParseIntError> {
+    s.as_ref().parse().map_err(|error| {
+        ParseIntError {
+            input: s.into(),
+            bits: u8::try_from(std::mem::size_of::<T>() * 8).expect("max is 128 bits for u128"),
+            // We detect if the type is signed by checking if -1 can be represented by it
+            // this way we don't have to implement special traits and optimizer will get rid of the
+            // computation.
+            is_signed: T::try_from(-1i8).is_ok(),
+            source: error,
+        }
+    })
+}
+
+impl_std_error!(ParseIntError, source);
+
+/// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using `fn`
+macro_rules! impl_tryfrom_str_through_int_single {
+    ($($from:ty, $to:ident $(, $fn:ident)?);*) => {
+        $(
+        impl std::convert::TryFrom<$from> for $to {
+            type Error = $crate::error::ParseIntError;
+
+            fn try_from(s: $from) -> Result<Self, Self::Error> {
+                $crate::parse::int(s).map($to $(:: $fn)?)
+            }
+        }
+        )*
+    }
+}
+pub(crate) use impl_tryfrom_str_through_int_single;
+
+/// Implements `FromStr` and `TryFrom<{&str, String, Box<str>}> for $to` using `parse::int`, mapping the output using `fn`
+///
+/// The `Error` type is `ParseIntError`
+macro_rules! impl_parse_str_through_int {
+    ($to:ident $(, $fn:ident)?) => {
+        $crate::parse::impl_tryfrom_str_through_int_single!(&str, $to $(, $fn)?; String, $to $(, $fn)?; Box<str>, $to $(, $fn)?);
+
+        impl std::str::FromStr for $to {
+            type Err = $crate::error::ParseIntError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                $crate::parse::int(s).map($to $(:: $fn)?)
+            }
+        }
+
+    }
+}
+pub(crate) use impl_parse_str_through_int;

--- a/src/pset/map/global.rs
+++ b/src/pset/map/global.rs
@@ -24,7 +24,7 @@ use crate::encode;
 use crate::encode::Decodable;
 use crate::endian::u32_to_array_le;
 use crate::pset::{self, map::Map, raw, Error};
-use crate::VarInt;
+use crate::{PackedLockTime, VarInt};
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPubKey, Fingerprint, KeySource};
 use secp256k1_zkp::Tweak;
 
@@ -64,7 +64,7 @@ pub struct TxData {
     pub version: u32,
     /// Locktime to use if no inputs specify a minimum locktime to use.
     /// May be omitted in which case it is interpreted as 0.
-    pub fallback_locktime: Option<u32>,
+    pub fallback_locktime: Option<crate::PackedLockTime>,
     /// Number of inputs in the transaction
     /// Not public. Users should not be able to mutate this directly
     /// This will be automatically whenever pset inputs are added
@@ -376,7 +376,7 @@ impl Decodable for Global {
         let mut tx_version: Option<u32> = None;
         let mut input_count: Option<VarInt> = None;
         let mut output_count: Option<VarInt> = None;
-        let mut fallback_locktime: Option<u32> = None;
+        let mut fallback_locktime: Option<PackedLockTime> = None;
         let mut tx_modifiable: Option<u8> = None;
         let mut elements_tx_modifiable_flag: Option<u8> = None;
 
@@ -395,7 +395,7 @@ impl Decodable for Global {
                         }
                         PSET_GLOBAL_FALLBACK_LOCKTIME => {
                             impl_pset_insert_pair! {
-                                fallback_locktime <= <raw_key: _>|<raw_value: u32>
+                                fallback_locktime <= <raw_key: _>|<raw_value: PackedLockTime>
                             }
                         }
                         PSET_GLOBAL_INPUT_COUNT => {

--- a/src/pset/map/input.rs
+++ b/src/pset/map/input.rs
@@ -23,7 +23,7 @@ use std::{
 use crate::taproot::{ControlBlock, LeafVersion, TapBranchHash, TapLeafHash};
 use crate::{schnorr, AssetId, ContractHash};
 
-use crate::confidential;
+use crate::{confidential, locktime};
 use crate::encode::{self, Decodable};
 use crate::hashes::{self, hash160, ripemd160, sha256, sha256d};
 use crate::pset::map::Map;
@@ -37,7 +37,7 @@ use bitcoin::{self, PublicKey};
 use hashes::Hash;
 use secp256k1_zkp::{self, RangeProof, Tweak, ZERO_TWEAK};
 
-use crate::OutPoint;
+use crate::{OutPoint, Sequence};
 
 /// Type: Non-Witness UTXO PSET_IN_NON_WITNESS_UTXO = 0x00
 const PSET_IN_NON_WITNESS_UTXO: u8 = 0x00;
@@ -216,11 +216,11 @@ pub struct Input {
     /// (PSET) Prevout vout of the input
     pub previous_output_index: u32,
     /// (PSET) Sequence number. If omitted, defaults to 0xffffffff
-    pub sequence: Option<u32>,
+    pub sequence: Option<Sequence>,
     /// (PSET) Minimum required locktime, as a UNIX timestamp. If present, must be greater than or equal to 500000000
-    pub required_time_locktime: Option<u32>,
+    pub required_time_locktime: Option<locktime::Time>,
     /// (PSET) Minimum required locktime, as a blockheight. If present, must be less than 500000000
-    pub required_height_locktime: Option<u32>,
+    pub required_height_locktime: Option<locktime::Height>,
     /// Serialized schnorr signature with sighash type for key spend
     pub tap_key_sig: Option<schnorr::SchnorrSig>,
     /// Map of <xonlypubkey>|<leafhash> with signature
@@ -607,17 +607,17 @@ impl Map for Input {
             }
             PSET_IN_SEQUENCE => {
                 impl_pset_insert_pair! {
-                    self.sequence <= <raw_key: _>|<raw_value: u32>
+                    self.sequence <= <raw_key: _>|<raw_value: Sequence>
                 }
             }
             PSET_IN_REQUIRED_TIME_LOCKTIME => {
                 impl_pset_insert_pair! {
-                    self.required_time_locktime <= <raw_key: _>|<raw_value: u32>
+                    self.required_time_locktime <= <raw_key: _>|<raw_value: locktime::Time>
                 }
             }
             PSET_IN_REQUIRED_HEIGHT_LOCKTIME => {
                 impl_pset_insert_pair! {
-                    self.required_height_locktime <= <raw_key: _>|<raw_value: u32>
+                    self.required_height_locktime <= <raw_key: _>|<raw_value: locktime::Height>
                 }
             }
             PSBT_IN_TAP_KEY_SIG => {

--- a/src/pset/serialize.rs
+++ b/src/pset/serialize.rs
@@ -59,6 +59,10 @@ impl_pset_de_serialize!(AssetId);
 impl_pset_de_serialize!(u8);
 impl_pset_de_serialize!(u32);
 impl_pset_de_serialize!(u64);
+impl_pset_de_serialize!(crate::PackedLockTime);
+impl_pset_de_serialize!(crate::Sequence);
+impl_pset_de_serialize!(crate::locktime::Height);
+impl_pset_de_serialize!(crate::locktime::Time);
 impl_pset_de_serialize!([u8; 32]);
 impl_pset_de_serialize!(VarInt);
 impl_pset_de_serialize!(Vec<Vec<u8>>); // scriptWitness

--- a/src/sighash.rs
+++ b/src/sighash.rs
@@ -28,6 +28,7 @@ use std::io;
 use crate::endian;
 use crate::transaction::{EcdsaSigHashType, Transaction, TxIn, TxOut, TxInWitness};
 use crate::confidential;
+use crate::Sequence;
 use std::fmt;
 use crate::taproot::{TapSighashHash, TapLeafHash};
 
@@ -635,7 +636,7 @@ impl<R: Deref<Target = Transaction>> SigHashCache<R> {
                     previous_output: input.previous_output,
                     is_pegin: input.is_pegin,
                     script_sig: if n == input_index { script_pubkey.clone() } else { Script::new() },
-                    sequence: if n != input_index && (sighash == EcdsaSigHashType::Single || sighash == EcdsaSigHashType::None) { 0 } else { input.sequence },
+                    sequence: if n != input_index && (sighash == EcdsaSigHashType::Single || sighash == EcdsaSigHashType::None) { Sequence::ZERO } else { input.sequence },
                     asset_issuance: input.asset_issuance,
                     witness: TxInWitness::default(),
                 });
@@ -812,12 +813,12 @@ impl<R: DerefMut<Target = Transaction>> SigHashCache<R> {
     ///
     /// This allows in-line signing such as
     /// ```
-    /// use elements::{Transaction, EcdsaSigHashType};
+    /// use elements::{PackedLockTime, Transaction, EcdsaSigHashType};
     /// use elements::sighash::SigHashCache;
     /// use elements::Script;
     /// use elements::confidential;
     ///
-    /// let mut tx_to_sign = Transaction { version: 2, lock_time: 0, input: Vec::new(), output: Vec::new() };
+    /// let mut tx_to_sign = Transaction { version: 2, lock_time: PackedLockTime::ZERO, input: Vec::new(), output: Vec::new() };
     /// let input_count = tx_to_sign.input.len();
     ///
     /// let mut sig_hasher = SigHashCache::new(&mut tx_to_sign);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -17,6 +17,7 @@
 
 use std::{io, fmt, str};
 use std::collections::HashMap;
+use std::convert::TryFrom;
 
 use bitcoin::{self, VarInt};
 use crate::hashes::{Hash, sha256};
@@ -25,8 +26,9 @@ use crate::{confidential, ContractHash};
 use crate::encode::{self, Encodable, Decodable};
 use crate::issuance::AssetId;
 use crate::opcodes;
+use crate::parse::impl_parse_str_through_int;
 use crate::script::Instruction;
-use crate::{PackedLockTime, Script, Sequence, Txid, Wtxid};
+use crate::{PackedLockTime, Script, Txid, Wtxid};
 use secp256k1_zkp::{
     RangeProof, SurjectionProof, Tweak, ZERO_TWEAK,
 };
@@ -138,6 +140,209 @@ impl ::std::str::FromStr for OutPoint {
         })
     }
 }
+
+/// Bitcoin transaction input sequence number.
+///
+/// The sequence field is used for:
+/// - Indicating whether absolute lock-time (specified in `lock_time` field of [`Transaction`])
+///   is enabled.
+/// - Indicating and encoding [BIP-68] relative lock-times.
+/// - Indicating whether a transcation opts-in to [BIP-125] replace-by-fee.
+///
+/// Note that transactions spending an output with `OP_CHECKLOCKTIMEVERIFY`MUST NOT use
+/// `Sequence::MAX` for the corresponding input. [BIP-65]
+///
+/// [BIP-65]: <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
+/// [BIP-68]: <https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki>
+/// [BIP-125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki>
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Sequence(pub u32);
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[non_exhaustive]
+/// An error in creating relative lock-times.
+pub enum RelativeLockTimeError {
+    /// The input was too large
+    IntegerOverflow(u32)
+}
+
+impl Sequence {
+    /// The maximum allowable sequence number.
+    ///
+    /// This sequence number disables lock-time and replace-by-fee.
+    pub const MAX: Self = Sequence(0xFFFFFFFF);
+    /// Zero value sequence.
+    ///
+    /// This sequence number enables replace-by-fee and lock-time.
+    pub const ZERO: Self = Sequence(0);
+    /// The sequence number that enables absolute lock-time but disables replace-by-fee
+    /// and relative lock-time.
+    pub const ENABLE_LOCKTIME_NO_RBF: Self = Sequence::MIN_NO_RBF;
+    /// The sequence number that enables replace-by-fee and absolute lock-time but
+    /// disables relative lock-time.
+    pub const ENABLE_RBF_NO_LOCKTIME: Self = Sequence(0xFFFFFFFD);
+
+    /// The lowest sequence number that does not opt-in for replace-by-fee.
+    ///
+    /// A transaction is considered to have opted in to replacement of itself
+    /// if any of it's inputs have a `Sequence` number less than this value
+    /// (Explicit Signalling [BIP-125]).
+    ///
+    /// [BIP-125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki]>
+    const MIN_NO_RBF: Self = Sequence(0xFFFFFFFE);
+    /// BIP-68 relative lock-time disable flag mask
+    const LOCK_TIME_DISABLE_FLAG_MASK: u32 = 0x80000000;
+    /// BIP-68 relative lock-time type flag mask
+    const LOCK_TYPE_MASK: u32 = 0x00400000;
+
+    /// Retuns `true` if the sequence number indicates that the transaction is finalised.
+    ///
+    /// The sequence number being equal to 0xffffffff on all txin sequences indicates
+    /// that the transaction is finalised.
+    #[inline]
+    pub fn is_final(&self) -> bool {
+        *self == Sequence::MAX
+    }
+
+    /// Returns true if the transaction opted-in to BIP125 replace-by-fee.
+    ///
+    /// Replace by fee is signaled by the sequence being less than 0xfffffffe which is checked by this method.
+    #[inline]
+    pub fn is_rbf(&self) -> bool {
+        *self < Sequence::MIN_NO_RBF
+    }
+
+    /// Returns `true` if the sequence has a relative lock-time.
+    #[inline]
+    pub fn is_relative_lock_time(&self) -> bool {
+        self.0 & Sequence::LOCK_TIME_DISABLE_FLAG_MASK == 0
+    }
+
+    /// Returns `true` if the sequence number encodes a block based relative lock-time.
+    #[inline]
+    pub fn is_height_locked(&self) -> bool {
+        self.is_relative_lock_time() & (self.0 & Sequence::LOCK_TYPE_MASK == 0)
+    }
+
+    /// Returns `true` if the sequene number encodes a time interval based relative lock-time.
+    #[inline]
+    pub fn is_time_locked(&self) -> bool {
+        self.is_relative_lock_time() & (self.0 & Sequence::LOCK_TYPE_MASK > 0)
+    }
+
+    /// Create a relative lock-time using block height.
+    #[inline]
+    pub fn from_height(height: u16) -> Self {
+        Sequence(u32::from(height))
+    }
+
+    /// Create a relative lock-time using time intervals where each interval is equivalent
+    /// to 512 seconds.
+    ///
+    /// Encoding finer granularity of time for relative lock-times is not supported in Bitcoin
+    #[inline]
+    pub fn from_512_second_intervals(intervals: u16) -> Self {
+        Sequence(u32::from(intervals) | Sequence::LOCK_TYPE_MASK)
+    }
+
+    /// Create a relative lock-time from seconds, converting the seconds into 512 second
+    /// interval with floor division.
+    ///
+    /// Will return an error if the input cannot be encoded in 16 bits.
+    #[inline]
+    pub fn from_seconds_floor(seconds: u32) -> Result<Self, RelativeLockTimeError> {
+        if let Ok(interval) = u16::try_from(seconds / 512) {
+            Ok(Sequence::from_512_second_intervals(interval))
+        } else {
+            Err(RelativeLockTimeError::IntegerOverflow(seconds))
+        }
+    }
+
+    /// Create a relative lock-time from seconds, converting the seconds into 512 second
+    /// interval with ceiling division.
+    ///
+    /// Will return an error if the input cannot be encoded in 16 bits.
+    #[inline]
+    pub fn from_seconds_ceil(seconds: u32) -> Result<Self, RelativeLockTimeError> {
+        if let Ok(interval) = u16::try_from((seconds + 511) / 512) {
+            Ok(Sequence::from_512_second_intervals(interval))
+        } else {
+            Err(RelativeLockTimeError::IntegerOverflow(seconds))
+        }
+    }
+
+    /// Returns `true` if the sequence number enables absolute lock-time ([`Transaction::lock_time`]).
+    #[inline]
+    pub fn enables_absolute_lock_time(&self) -> bool {
+        !self.is_final()
+    }
+
+    /// Create a sequence from a u32 value.
+    #[inline]
+    pub fn from_consensus(n: u32) -> Self {
+        Sequence(n)
+    }
+
+    /// Returns the inner 32bit integer value of Sequence.
+    #[inline]
+    pub fn to_consensus_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl Default for Sequence {
+    /// The default value of sequence is 0xffffffff.
+    fn default() -> Self {
+        Sequence::MAX
+    }
+}
+
+impl From<Sequence> for u32 {
+    fn from(sequence: Sequence) -> u32 {
+        sequence.0
+    }
+}
+
+impl fmt::Display for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::LowerHex for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for Sequence {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for RelativeLockTimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::IntegerOverflow(val) => write!(f, "input of {} was too large", val)
+        }
+    }
+}
+
+impl_parse_str_through_int!(Sequence);
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for RelativeLockTimeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::IntegerOverflow(_) => None
+        }
+    }
+}
+
 
 /// Transaction input witness
 #[derive(Clone, Default, PartialEq, Eq, Debug, Hash)]
@@ -751,6 +956,18 @@ impl Transaction {
             *entry += out.value.explicit().expect("is_fee");
         }
         fees
+    }
+}
+
+impl Encodable for Sequence {
+    fn consensus_encode<W: io::Write>(&self, w: W) -> Result<usize, encode::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for Sequence {
+    fn consensus_decode<R: io::Read>(r: R) -> Result<Self, encode::Error> {
+        Decodable::consensus_decode(r).map(Sequence)
     }
 }
 

--- a/tests/taproot.rs
+++ b/tests/taproot.rs
@@ -18,8 +18,8 @@ use elements::sighash::{self, SigHashCache};
 use elements::taproot::{LeafVersion, TapTweakHash, TaprootBuilder, TaprootSpendInfo, TapLeafHash};
 use elements::OutPoint;
 use elements::{
-    confidential, opcodes, AssetIssuance, BlockHash, SchnorrSig, SchnorrSigHashType, Script,
-    TxInWitness, TxOut, Txid,
+    confidential, opcodes, AssetIssuance, BlockHash, PackedLockTime, SchnorrSig, SchnorrSigHashType, Script,
+    Sequence, TxInWitness, TxOut, Txid,
 };
 use elements::{AddressParams, Transaction, TxIn, TxOutSecrets};
 use elementsd::bitcoincore_rpc::jsonrpc::serde_json::{json, Value};
@@ -168,13 +168,17 @@ fn taproot_spend_test(
     let test_data = funded_tap_txout(&elementsd, &secp, blind_prevout);
 
     // create a new spend that spends the above output
-    let mut tx = Transaction::default();
-    tx.version = 2;
+    let mut tx = Transaction {
+        version: 2,
+        lock_time: PackedLockTime::ZERO,
+        input: vec![],
+        output: vec![],
+    };
     let inp = TxIn {
         previous_output: test_data.prevout,
         is_pegin: false,
         script_sig: Script::new(),
-        sequence: u32::MAX - 1,
+        sequence: Sequence::MAX,
         asset_issuance: AssetIssuance::default(),
         witness: TxInWitness::default(),
     };


### PR DESCRIPTION
The PSET stuff I'm a little uncertain about -- PSBT2 brings new locktime logic in that doesn't exist in PSBT0. My new logic is essentially the same, except that while previously we would allow the user to specify invalid locktimes (since we just parsed a u32 with no further checking) now we don't.

I think, when we do this upstream in rust-bitcoin, we should probably introduce some helper methods into LockTime, because currently there are conversions from Time/Height into LockTime that feel misplaced.

Also, it is really unclear what the difference between LockTime and PackedLockTime is supposed to be, so I did my best to copy rust-bitcoin.
