### PR TITLE
Tap tweak

### DIFF
--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -181,6 +181,27 @@ impl TweakedKeyPair {
     }
 }
 
+impl From<TweakedPublicKey> for XOnlyPublicKey {
+    #[inline]
+    fn from(pair: TweakedPublicKey) -> Self {
+        pair.0
+    }
+}
+
+impl From<TweakedKeyPair> for KeyPair {
+    #[inline]
+    fn from(pair: TweakedKeyPair) -> Self {
+        pair.0
+    }
+}
+
+impl From<TweakedKeyPair> for TweakedPublicKey {
+    #[inline]
+    fn from(pair: TweakedKeyPair) -> Self {
+        TweakedPublicKey::from_keypair(pair)
+    }
+}
+
 /// A BIP340-341 serialized schnorr signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -149,6 +149,31 @@ impl TweakedPublicKey {
     }
 }
 
+impl TweakedKeyPair {
+    /// Creates a new [`TweakedKeyPair`] from a [`KeyPair`]. No tweak is applied, consider
+    /// calling `tap_tweak` on an [`UntweakedKeyPair`] instead of using this constructor.
+    ///
+    /// This method is dangerous and can lead to loss of funds if used incorrectly.
+    /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
+    #[inline]
+    pub fn dangerous_assume_tweaked(pair: KeyPair) -> TweakedKeyPair {
+        TweakedKeyPair(pair)
+    }
+
+    /// Returns the underlying key pair.
+    #[inline]
+    pub fn to_inner(self) -> KeyPair {
+        self.0
+    }
+
+    /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeyPair`].
+    #[inline]
+    pub fn public_parts(&self) -> (TweakedPublicKey, secp256k1_zkp::Parity) {
+        let (xonly, parity) = self.0.x_only_public_key();
+        (TweakedPublicKey(xonly), parity)
+    }
+}
+
 /// A BIP340-341 serialized schnorr signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -133,6 +133,13 @@ impl TapTweak for UntweakedKeyPair {
 }
 
 impl TweakedPublicKey {
+    /// Returns the [`TweakedPublicKey`] for `keypair`.
+    #[inline]
+    pub fn from_keypair(keypair: TweakedKeyPair) -> Self {
+        let (xonly, _parity) = keypair.0.x_only_public_key();
+        TweakedPublicKey(xonly)
+    }
+
     /// Create a new [TweakedPublicKey] from a [PublicKey]. No tweak is applied.
     pub fn new(key: XOnlyPublicKey) -> TweakedPublicKey {
         TweakedPublicKey(key)

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -107,6 +107,12 @@ impl TapTweakHash {
         }
         TapTweakHash::from_engine(eng)
     }
+
+    /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
+    pub fn to_scalar(self) -> Scalar {
+        // This is statistically extremely unlikely to panic.
+        Scalar::from_be_bytes(self.into_inner()).expect("hash value greater than curve order")
+    }
 }
 
 impl TapLeafHash {


### PR DESCRIPTION
Updates `TapTweak` to [latest rust-bitcoin](https://docs.rs/bitcoin/latest/bitcoin/key/trait.TapTweak.html) and adds `TweakedKeyPair`.