### PR TITLE
Remove std feature gates

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,14 +7,10 @@ pub use crate::parse::ParseIntError;
 macro_rules! impl_std_error {
     // No source available
     ($type:ty) => {
-        #[cfg(feature = "std")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
         impl std::error::Error for $type {}
     };
     // Struct with $field as source
     ($type:ty, $field:ident) => {
-        #[cfg(feature = "std")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
         impl std::error::Error for $type {
             fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
                 Some(&self.$field)
@@ -29,18 +25,11 @@ pub(crate) use impl_std_error;
 /// lost for no-std builds.
 macro_rules! write_err {
     ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
-        {   
-            #[cfg(feature = "std")]
-            {   
-                let _ = &$source;   // Prevents clippy warnings.
-                write!($writer, $string $(, $args)*)
-            }   
-            #[cfg(not(feature = "std"))]
-            {   
-                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
-            }   
-        }   
-    }   
+        {
+            let _ = &$source;   // Prevents clippy warnings.
+            write!($writer, $string $(, $args)*)
+        }
+    }
 }
 pub(crate) use write_err;
 

--- a/src/locktime.rs
+++ b/src/locktime.rs
@@ -600,8 +600,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -665,8 +663,6 @@ impl fmt::Display for ConversionError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for ConversionError {}
 
 /// Describes the two types of locking, lock-by-blockheight and lock-by-blocktime.
@@ -707,8 +703,6 @@ impl fmt::Display for OperationError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for OperationError {}
 
 #[cfg(test)]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -333,8 +333,6 @@ impl fmt::Display for RelativeLockTimeError {
 
 impl_parse_str_through_int!(Sequence);
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for RelativeLockTimeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {


### PR DESCRIPTION
There is no `std` feature in rust-elements. This is a copy-and-paste error from rust-bitcoin.