### PR TITLE
Implement Ord for Transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ json-contract = [ "serde_json" ]
 
 [dependencies]
 bitcoin = "0.30.0"
-secp256k1-zkp = { version = "0.9.1", features = [ "global-context", "bitcoin_hashes" ] }
+secp256k1-zkp = { version = "0.9.2", features = [ "global-context", "bitcoin_hashes" ] }
 slip21 = "0.2.0"
 
 # Used for ContractHash::from_json_contract.

--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -33,7 +33,7 @@ use crate::encode::{self, Decodable, Encodable};
 use crate::issuance::AssetId;
 
 /// A CT commitment to an amount
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Value {
     /// No value
     Null,
@@ -252,7 +252,7 @@ impl<'de> Deserialize<'de> for Value {
 }
 
 /// A CT commitment to an asset
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Asset {
     /// No value
     Null,


### PR DESCRIPTION
This haven't any consensuns meaning but it's useful to have transactions in ordered collections

~~depends on https://github.com/BlockstreamResearch/rust-secp256k1-zkp/pull/68~~ merged

~~draft because needs rust-secp256k1-zkp release https://github.com/BlockstreamResearch/rust-secp256k1-zkp/pull/70~~