### PR TITLE
confidential: Don't reverse explicit values for serde

### DIFF
--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -202,7 +202,7 @@ impl Serialize for Value {
             Value::Null => seq.serialize_element(&0u8)?,
             Value::Explicit(n) => {
                 seq.serialize_element(&1u8)?;
-                seq.serialize_element(&u64::swap_bytes(n))?;
+                seq.serialize_element(&n)?;
             }
             Value::Confidential(commitment) => {
                 seq.serialize_element(&2u8)?;
@@ -232,7 +232,7 @@ impl<'de> Deserialize<'de> for Value {
                     Some(0) => Ok(Value::Null),
                     Some(1) => {
                         match access.next_element()? {
-                            Some(x) => Ok(Value::Explicit(u64::swap_bytes(x))),
+                            Some(x) => Ok(Value::Explicit(x)),
                             None => Err(A::Error::custom("missing explicit value")),
                         }
                     }


### PR DESCRIPTION
So this is a breaking change. It might affect people actually using the serde serialization of `confidential::Value::Explicit` right now. Which is really unfortunate.

But IMO this is a big. We for some miraculous reason (probably a mistake on some programmer's end) reverse the bytes when consensus-encoding explicit values. That's fine. But somehow we also ended up doing this for serde, which makes no sense. 

I'm hitting this when trying to use this type in a Web setting through WASM and a small number of satoshis will (when reversed) cause a JS overflow (which only supports 53 bit integers).