### PR TITLE
Add to and from base64 string to pset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ json-contract = [ "serde_json" ]
     "secp256k1-zkp/serde",
     "actual-serde"
 ]
+base64 = ["bitcoin/base64"]
 
 [dependencies]
 bitcoin = "0.30.0"
@@ -37,7 +38,6 @@ serde_test = "1.0.19"
 serde_json = "1.0"
 serde_cbor = "0.8"   # older than latest version to support 1.41.1
 bincode = "1.3"
-base64 = "0.13.0"
 
 [[example]]
 name = "pset_blind_coinjoin"

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -4,12 +4,12 @@ FEATURES="serde"
 
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.48"; then
-    cargo update -p once_cell --precise 1.13.1
-    cargo update -p quote --precise 1.0.28
-    cargo update -p proc-macro2 --precise 1.0.63
     cargo update -p serde_json --precise 1.0.99
     # 1.0.157 uses syn 2.0 which requires edition 2018
     cargo update -p serde --precise 1.0.156
+    cargo update -p once_cell --precise 1.13.1
+    cargo update -p quote --precise 1.0.28
+    cargo update -p proc-macro2 --precise 1.0.63
     cargo update -p serde_test --precise 1.0.156
 
     cargo update -p log --precise 0.4.18

--- a/elementsd-tests/Cargo.toml
+++ b/elementsd-tests/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.13.0"
 bitcoin = "0.30.0"
-elements = {path = "../"}
+elements = {path = "../", features = ["base64"]}
 elementsd = "0.8.0"
 rand = "0.8"
 

--- a/src/blech32.rs
+++ b/src/blech32.rs
@@ -289,7 +289,7 @@ mod test {
     fn test_checksum() {
         let data = vec![7,2,3,4,5,6,7,8,9,234,123,213,16];
         let cs = create_checksum(b"lq", &data.to_base32(), Variant::Blech32);
-        let expected_cs = vec![22,13,13,5,4,4,23,7,28,21,30,12];
+        let expected_cs = [22,13,13,5,4,4,23,7,28,21,30,12];
         for i in 0..expected_cs.len() {
             assert_eq!(expected_cs[i], *cs[i].as_ref());
         }

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -30,6 +30,9 @@ mod map;
 pub mod raw;
 pub mod serialize;
 
+#[cfg(feature = "base64")]
+mod str;
+
 use crate::blind::{BlindAssetProofs, BlindValueProofs};
 use crate::confidential;
 use crate::encode::{self, Decodable, Encodable};

--- a/src/pset/str.rs
+++ b/src/pset/str.rs
@@ -1,0 +1,43 @@
+use super::PartiallySignedTransaction;
+
+#[derive(Debug)]
+pub enum Error {
+    Base64(bitcoin::base64::DecodeError),
+    Deserialize(crate::encode::Error)
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Base64(_) => write!(f, "Base64 error"),
+            Error::Deserialize(_) => write!(f, "Deserialize error"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Base64(e) => Some(e),
+            Error::Deserialize(e) => Some(e),
+        }
+    }
+
+}
+
+impl std::str::FromStr for PartiallySignedTransaction {
+    type Err=Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = bitcoin::base64::decode(s).map_err(Error::Base64)?;
+        crate::encode::deserialize(&bytes).map_err(Error::Deserialize)
+    }
+}
+
+impl std::fmt::Display for PartiallySignedTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let bytes = crate::encode::serialize(self);
+        let base64 = bitcoin::base64::encode(bytes);
+        write!(f, "{}", base64)
+    }
+}


### PR DESCRIPTION
via standard trait Display and FromStr like it's done in rust-bitcoin PSBT.

Reuse rust-bitcoin base64 re-exported