### PR TITLE
rename pset::str::Error to ParseError and expose it

### DIFF
--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -33,6 +33,9 @@ pub mod serialize;
 #[cfg(feature = "base64")]
 mod str;
 
+#[cfg(feature = "base64")]
+pub use self::str::ParseError;
+
 use crate::blind::{BlindAssetProofs, BlindValueProofs};
 use crate::confidential;
 use crate::encode::{self, Decodable, Encodable};

--- a/src/pset/str.rs
+++ b/src/pset/str.rs
@@ -1,36 +1,39 @@
 use super::PartiallySignedTransaction;
 
+/// Possible errors when parsing a PSET from a string
 #[derive(Debug)]
-pub enum Error {
+pub enum ParseError {
+    /// Base64 decoding error
     Base64(bitcoin::base64::DecodeError),
+    /// PSET binary encoding error
     Deserialize(crate::encode::Error)
 }
 
-impl core::fmt::Display for Error {
+impl core::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Base64(_) => write!(f, "Base64 error"),
-            Error::Deserialize(_) => write!(f, "Deserialize error"),
+            ParseError::Base64(_) => write!(f, "Base64 error"),
+            ParseError::Deserialize(_) => write!(f, "Deserialize error"),
         }
     }
 }
 
-impl std::error::Error for Error {
+impl std::error::Error for ParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::Base64(e) => Some(e),
-            Error::Deserialize(e) => Some(e),
+            ParseError::Base64(e) => Some(e),
+            ParseError::Deserialize(e) => Some(e),
         }
     }
 
 }
 
 impl std::str::FromStr for PartiallySignedTransaction {
-    type Err=Error;
+    type Err=ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = bitcoin::base64::decode(s).map_err(Error::Base64)?;
-        crate::encode::deserialize(&bytes).map_err(Error::Deserialize)
+        let bytes = bitcoin::base64::decode(s).map_err(ParseError::Base64)?;
+        crate::encode::deserialize(&bytes).map_err(ParseError::Deserialize)
     }
 }
 


### PR DESCRIPTION
Otherwise the pset decoding from string cannot be used downstream

fix #175 