### PR TITLE
Add newtype ProprietaryType

### DIFF
--- a/src/pset/map/global.rs
+++ b/src/pset/map/global.rs
@@ -166,7 +166,7 @@ impl Map for Global {
             | PSET_GLOBAL_TX_VERSION => return Err(Error::DuplicateKey(raw_key).into()),
             PSET_GLOBAL_PROPRIETARY => {
                 let prop_key = raw::ProprietaryKey::from_key(raw_key.clone())?;
-                if prop_key.is_pset_key() && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_SCALAR {
+                if prop_key.is_pset_key() && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_SCALAR.into() {
                     if raw_value.is_empty() && prop_key.key.len() == 32 {
                         let scalar = Tweak::from_slice(&prop_key.key)?;
                         if !self.scalars.contains(&scalar) {
@@ -178,7 +178,7 @@ impl Map for Global {
                         return Err(Error::InvalidKey(raw_key))?;
                     }
                 } else if prop_key.is_pset_key()
-                    && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE
+                    && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE.into()
                 {
                     if prop_key.key.is_empty() && raw_value.len() == 1 {
                         self.elements_tx_modifiable_flag = Some(raw_value[0]);
@@ -263,7 +263,7 @@ impl Map for Global {
         // Serialize scalars and elements tx modifiable
         for scalar in &self.scalars {
             let key = raw::ProprietaryKey::from_pset_pair(
-                PSBT_ELEMENTS_GLOBAL_SCALAR,
+                PSBT_ELEMENTS_GLOBAL_SCALAR.into(),
                 scalar.as_ref().to_vec(),
             );
             rv.push(raw::Pair {
@@ -273,7 +273,7 @@ impl Map for Global {
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.elements_tx_modifiable_flag as <PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE, _>)
+            rv.push_prop(self.elements_tx_modifiable_flag as <PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE.into(), _>)
         }
 
         for (key, value) in self.proprietary.iter() {
@@ -459,7 +459,7 @@ impl Decodable for Global {
                         PSET_GLOBAL_PROPRIETARY => {
                             let prop_key = raw::ProprietaryKey::from_key(raw_key.clone())?;
                             if prop_key.is_pset_key()
-                                && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_SCALAR
+                                && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_SCALAR.into()
                             {
                                 if raw_value.is_empty() && prop_key.key.len() == 32 {
                                     let scalar = Tweak::from_slice(&prop_key.key)?;
@@ -472,7 +472,7 @@ impl Decodable for Global {
                                     return Err(Error::InvalidKey(raw_key))?;
                                 }
                             } else if prop_key.is_pset_key()
-                                && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE
+                                && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE.into()
                             {
                                 if prop_key.key.is_empty() && raw_value.len() == 1 {
                                     elements_tx_modifiable_flag = Some(raw_value[0]);

--- a/src/pset/map/input.rs
+++ b/src/pset/map/input.rs
@@ -12,6 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use std::convert::TryInto;
 use std::fmt;
 use std::{
     cmp,
@@ -27,7 +28,7 @@ use crate::{confidential, locktime};
 use crate::encode::{self, Decodable};
 use crate::hashes::{self, hash160, ripemd160, sha256, sha256d, Hash};
 use crate::pset::map::Map;
-use crate::pset::raw;
+use crate::pset::raw::{self};
 use crate::pset::serialize;
 use crate::pset::{self, error, Error};
 use crate::{transaction::SighashTypeParseError, SchnorrSighashType};
@@ -652,57 +653,57 @@ impl Map for Input {
             PSET_IN_PROPRIETARY => {
                 let prop_key = raw::ProprietaryKey::from_key(raw_key.clone())?;
                 if prop_key.is_pset_key() {
-                    match prop_key.subtype {
-                        PSBT_ELEMENTS_IN_ISSUANCE_VALUE => {
+                    match prop_key.subtype.try_into() {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_VALUE) => {
                             impl_pset_prop_insert_pair!(self.issuance_value_amount <= <raw_key: _> | <raw_value : u64>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT) => {
                             impl_pset_prop_insert_pair!(self.issuance_value_comm <= <raw_key: _> | <raw_value : secp256k1_zkp::PedersenCommitment>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_VALUE_RANGEPROOF => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_VALUE_RANGEPROOF) => {
                             impl_pset_prop_insert_pair!(self.issuance_value_rangeproof <= <raw_key: _> | <raw_value : Box<RangeProof>>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_KEYS_RANGEPROOF => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_KEYS_RANGEPROOF) => {
                             impl_pset_prop_insert_pair!(self.issuance_keys_rangeproof <= <raw_key: _> | <raw_value : Box<RangeProof>>)
                         }
-                        PSBT_ELEMENTS_IN_PEG_IN_TX => {
+                        Ok(PSBT_ELEMENTS_IN_PEG_IN_TX) => {
                             impl_pset_prop_insert_pair!(self.pegin_tx <= <raw_key: _> | <raw_value : bitcoin::Transaction>)
                         }
                         // No support for TxOutProof struct yet
-                        PSBT_ELEMENTS_IN_PEG_IN_TXOUT_PROOF => {
+                        Ok(PSBT_ELEMENTS_IN_PEG_IN_TXOUT_PROOF) => {
                             impl_pset_prop_insert_pair!(self.pegin_txout_proof <= <raw_key: _> | <raw_value : Vec<u8>>)
                         }
-                        PSBT_ELEMENTS_IN_PEG_IN_GENESIS => {
+                        Ok(PSBT_ELEMENTS_IN_PEG_IN_GENESIS) => {
                             impl_pset_prop_insert_pair!(self.pegin_genesis_hash <= <raw_key: _> | <raw_value : BlockHash>)
                         }
-                        PSBT_ELEMENTS_IN_PEG_IN_CLAIM_SCRIPT => {
+                        Ok(PSBT_ELEMENTS_IN_PEG_IN_CLAIM_SCRIPT) => {
                             impl_pset_prop_insert_pair!(self.pegin_claim_script <= <raw_key: _> | <raw_value : Script>)
                         }
-                        PSBT_ELEMENTS_IN_PEG_IN_VALUE => {
+                        Ok(PSBT_ELEMENTS_IN_PEG_IN_VALUE) => {
                             impl_pset_prop_insert_pair!(self.pegin_value <= <raw_key: _> | <raw_value : u64>)
                         }
-                        PSBT_ELEMENTS_IN_PEG_IN_WITNESS => {
+                        Ok(PSBT_ELEMENTS_IN_PEG_IN_WITNESS) => {
                             impl_pset_prop_insert_pair!(self.pegin_witness <= <raw_key: _> | <raw_value : Vec<Vec<u8>>>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS) => {
                             impl_pset_prop_insert_pair!(self.issuance_inflation_keys <= <raw_key: _> | <raw_value : u64>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS_COMMITMENT => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS_COMMITMENT) => {
                             impl_pset_prop_insert_pair!(self.issuance_inflation_keys_comm <= <raw_key: _> | <raw_value : secp256k1_zkp::PedersenCommitment>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_BLINDING_NONCE => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_BLINDING_NONCE) => {
                             impl_pset_prop_insert_pair!(self.issuance_blinding_nonce <= <raw_key: _> | <raw_value : Tweak>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_ASSET_ENTROPY => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_ASSET_ENTROPY) => {
                             impl_pset_prop_insert_pair!(self.issuance_asset_entropy <= <raw_key: _> | <raw_value : [u8;32]>)
                         }
-                        PSBT_ELEMENTS_IN_UTXO_RANGEPROOF => {
+                        Ok(PSBT_ELEMENTS_IN_UTXO_RANGEPROOF) => {
                             impl_pset_prop_insert_pair!(self.in_utxo_rangeproof <= <raw_key: _> | <raw_value : Box<RangeProof>>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_BLIND_VALUE_PROOF => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_BLIND_VALUE_PROOF) => {
                             impl_pset_prop_insert_pair!(self.in_issuance_blind_value_proof <= <raw_key: _> | <raw_value : Box<RangeProof>>)
                         }
-                        PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF => {
+                        Ok(PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF) => {
                             impl_pset_prop_insert_pair!(self.in_issuance_blind_inflation_keys_proof <= <raw_key: _> | <raw_value : Box<RangeProof>>)
                         }
                         _ => match self.proprietary.entry(prop_key) {
@@ -815,92 +816,92 @@ impl Map for Input {
         }
 
         impl_pset_get_pair! {
-            rv.push(self.tap_script_sigs as <PSBT_IN_TAP_SCRIPT_SIG, (schnorr::PublicKey, TapLeafHash)>)
+            rv.push(self.tap_script_sigs as <PSBT_IN_TAP_SCRIPT_SIG.into(), (schnorr::PublicKey, TapLeafHash)>)
         }
 
         impl_pset_get_pair! {
-            rv.push(self.tap_scripts as <PSBT_IN_TAP_LEAF_SCRIPT, ControlBlock>)
+            rv.push(self.tap_scripts as <PSBT_IN_TAP_LEAF_SCRIPT.into(), ControlBlock>)
         }
 
         impl_pset_get_pair! {
-            rv.push(self.tap_key_origins as <PSBT_IN_TAP_BIP32_DERIVATION,
+            rv.push(self.tap_key_origins as <PSBT_IN_TAP_BIP32_DERIVATION.into(),
                 schnorr::PublicKey>)
         }
 
         impl_pset_get_pair! {
-            rv.push(self.tap_internal_key as <PSBT_IN_TAP_INTERNAL_KEY, _>)
+            rv.push(self.tap_internal_key as <PSBT_IN_TAP_INTERNAL_KEY.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push(self.tap_merkle_root as <PSBT_IN_TAP_MERKLE_ROOT, _>)
+            rv.push(self.tap_merkle_root as <PSBT_IN_TAP_MERKLE_ROOT.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_value_amount as <PSBT_ELEMENTS_IN_ISSUANCE_VALUE, _>)
+            rv.push_prop(self.issuance_value_amount as <PSBT_ELEMENTS_IN_ISSUANCE_VALUE.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_value_comm as <PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT, _>)
+            rv.push_prop(self.issuance_value_comm as <PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_value_rangeproof as <PSBT_ELEMENTS_IN_ISSUANCE_VALUE_RANGEPROOF, _>)
+            rv.push_prop(self.issuance_value_rangeproof as <PSBT_ELEMENTS_IN_ISSUANCE_VALUE_RANGEPROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_keys_rangeproof as <PSBT_ELEMENTS_IN_ISSUANCE_KEYS_RANGEPROOF, _>)
+            rv.push_prop(self.issuance_keys_rangeproof as <PSBT_ELEMENTS_IN_ISSUANCE_KEYS_RANGEPROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.pegin_tx as <PSBT_ELEMENTS_IN_PEG_IN_TX, _>)
+            rv.push_prop(self.pegin_tx as <PSBT_ELEMENTS_IN_PEG_IN_TX.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.pegin_txout_proof as <PSBT_ELEMENTS_IN_PEG_IN_TXOUT_PROOF, _>)
+            rv.push_prop(self.pegin_txout_proof as <PSBT_ELEMENTS_IN_PEG_IN_TXOUT_PROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.pegin_genesis_hash as <PSBT_ELEMENTS_IN_PEG_IN_GENESIS, _>)
+            rv.push_prop(self.pegin_genesis_hash as <PSBT_ELEMENTS_IN_PEG_IN_GENESIS.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.pegin_claim_script as <PSBT_ELEMENTS_IN_PEG_IN_CLAIM_SCRIPT, _>)
+            rv.push_prop(self.pegin_claim_script as <PSBT_ELEMENTS_IN_PEG_IN_CLAIM_SCRIPT.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.pegin_value as <PSBT_ELEMENTS_IN_PEG_IN_VALUE, _>)
+            rv.push_prop(self.pegin_value as <PSBT_ELEMENTS_IN_PEG_IN_VALUE.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.pegin_witness as <PSBT_ELEMENTS_IN_PEG_IN_WITNESS, _>)
+            rv.push_prop(self.pegin_witness as <PSBT_ELEMENTS_IN_PEG_IN_WITNESS.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_inflation_keys as <PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS, _>)
+            rv.push_prop(self.issuance_inflation_keys as <PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_inflation_keys_comm as <PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS_COMMITMENT, _>)
+            rv.push_prop(self.issuance_inflation_keys_comm as <PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS_COMMITMENT.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_blinding_nonce as <PSBT_ELEMENTS_IN_ISSUANCE_BLINDING_NONCE, _>)
+            rv.push_prop(self.issuance_blinding_nonce as <PSBT_ELEMENTS_IN_ISSUANCE_BLINDING_NONCE.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.issuance_asset_entropy as <PSBT_ELEMENTS_IN_ISSUANCE_ASSET_ENTROPY, _>)
+            rv.push_prop(self.issuance_asset_entropy as <PSBT_ELEMENTS_IN_ISSUANCE_ASSET_ENTROPY.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.in_utxo_rangeproof as <PSBT_ELEMENTS_IN_UTXO_RANGEPROOF, _>)
+            rv.push_prop(self.in_utxo_rangeproof as <PSBT_ELEMENTS_IN_UTXO_RANGEPROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.in_issuance_blind_value_proof as <PSBT_ELEMENTS_IN_ISSUANCE_BLIND_VALUE_PROOF, _>)
+            rv.push_prop(self.in_issuance_blind_value_proof as <PSBT_ELEMENTS_IN_ISSUANCE_BLIND_VALUE_PROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.in_issuance_blind_inflation_keys_proof as <PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF, _>)
+            rv.push_prop(self.in_issuance_blind_inflation_keys_proof as <PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF.into(), _>)
         }
 
         for (key, value) in self.proprietary.iter() {

--- a/src/pset/map/output.rs
+++ b/src/pset/map/output.rs
@@ -13,6 +13,7 @@
 //
 
 use std::collections::btree_map::Entry;
+use std::convert::TryInto;
 use std::{collections::BTreeMap, io};
 
 use crate::taproot::TapLeafHash;
@@ -343,35 +344,35 @@ impl Map for Output {
             PSET_OUT_PROPRIETARY => {
                 let prop_key = raw::ProprietaryKey::from_key(raw_key.clone())?;
                 if prop_key.is_pset_key() {
-                    match prop_key.subtype {
-                        PSBT_ELEMENTS_OUT_VALUE_COMMITMENT => {
+                    match prop_key.subtype.try_into() {
+                        Ok(PSBT_ELEMENTS_OUT_VALUE_COMMITMENT)  => {
                             impl_pset_prop_insert_pair!(self.amount_comm <= <raw_key: _> | <raw_value : secp256k1_zkp::PedersenCommitment>)
                         }
-                        PSBT_ELEMENTS_OUT_ASSET => {
+                        Ok(PSBT_ELEMENTS_OUT_ASSET) => {
                             impl_pset_prop_insert_pair!(self.asset <= <raw_key: _> | <raw_value : AssetId>)
                         }
-                        PSBT_ELEMENTS_OUT_ASSET_COMMITMENT => {
+                        Ok(PSBT_ELEMENTS_OUT_ASSET_COMMITMENT) => {
                             impl_pset_prop_insert_pair!(self.asset_comm <= <raw_key: _> | <raw_value : Generator>)
                         }
-                        PSBT_ELEMENTS_OUT_VALUE_RANGEPROOF => {
+                        Ok(PSBT_ELEMENTS_OUT_VALUE_RANGEPROOF) => {
                             impl_pset_prop_insert_pair!(self.value_rangeproof <= <raw_key: _> | <raw_value : Box<RangeProof>>)
                         }
-                        PSBT_ELEMENTS_OUT_ASSET_SURJECTION_PROOF => {
+                        Ok(PSBT_ELEMENTS_OUT_ASSET_SURJECTION_PROOF) => {
                             impl_pset_prop_insert_pair!(self.asset_surjection_proof <= <raw_key: _> | <raw_value : Box<SurjectionProof>>)
                         }
-                        PSBT_ELEMENTS_OUT_BLINDING_PUBKEY => {
+                        Ok(PSBT_ELEMENTS_OUT_BLINDING_PUBKEY) => {
                             impl_pset_prop_insert_pair!(self.blinding_key <= <raw_key: _> | <raw_value : PublicKey>)
                         }
-                        PSBT_ELEMENTS_OUT_ECDH_PUBKEY => {
+                        Ok(PSBT_ELEMENTS_OUT_ECDH_PUBKEY) => {
                             impl_pset_prop_insert_pair!(self.ecdh_pubkey <= <raw_key: _> | <raw_value : PublicKey>)
                         }
-                        PSBT_ELEMENTS_OUT_BLINDER_INDEX => {
+                        Ok(PSBT_ELEMENTS_OUT_BLINDER_INDEX) => {
                             impl_pset_prop_insert_pair!(self.blinder_index <= <raw_key: _> | <raw_value : u32>)
                         }
-                        PSBT_ELEMENTS_OUT_BLIND_VALUE_PROOF => {
+                        Ok(PSBT_ELEMENTS_OUT_BLIND_VALUE_PROOF) => {
                             impl_pset_prop_insert_pair!(self.blind_value_proof <= <raw_key: _> | <raw_value : Box<RangeProof>>)
                         }
-                        PSBT_ELEMENTS_OUT_BLIND_ASSET_PROOF => {
+                        Ok(PSBT_ELEMENTS_OUT_BLIND_ASSET_PROOF) => {
                             impl_pset_prop_insert_pair!(self.blind_asset_proof <= <raw_key: _> | <raw_value : Box<SurjectionProof>>)
                         }
                         _ => match self.proprietary.entry(prop_key) {
@@ -439,15 +440,15 @@ impl Map for Output {
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.amount_comm as <PSBT_ELEMENTS_OUT_VALUE_COMMITMENT, _>)
+            rv.push_prop(self.amount_comm as <PSBT_ELEMENTS_OUT_VALUE_COMMITMENT.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.asset as <PSBT_ELEMENTS_OUT_ASSET, _>)
+            rv.push_prop(self.asset as <PSBT_ELEMENTS_OUT_ASSET.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.asset_comm as <PSBT_ELEMENTS_OUT_ASSET_COMMITMENT, _>)
+            rv.push_prop(self.asset_comm as <PSBT_ELEMENTS_OUT_ASSET_COMMITMENT.into(), _>)
         }
 
         // Mandatory field: Script
@@ -461,31 +462,31 @@ impl Map for Output {
 
         // Prop Output fields
         impl_pset_get_pair! {
-            rv.push_prop(self.value_rangeproof as <PSBT_ELEMENTS_OUT_VALUE_RANGEPROOF, _>)
+            rv.push_prop(self.value_rangeproof as <PSBT_ELEMENTS_OUT_VALUE_RANGEPROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.asset_surjection_proof as <PSBT_ELEMENTS_OUT_ASSET_SURJECTION_PROOF, _>)
+            rv.push_prop(self.asset_surjection_proof as <PSBT_ELEMENTS_OUT_ASSET_SURJECTION_PROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.blinding_key as <PSBT_ELEMENTS_OUT_BLINDING_PUBKEY, _>)
+            rv.push_prop(self.blinding_key as <PSBT_ELEMENTS_OUT_BLINDING_PUBKEY.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.ecdh_pubkey as <PSBT_ELEMENTS_OUT_ECDH_PUBKEY, _>)
+            rv.push_prop(self.ecdh_pubkey as <PSBT_ELEMENTS_OUT_ECDH_PUBKEY.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.blinder_index as <PSBT_ELEMENTS_OUT_BLINDER_INDEX, _>)
+            rv.push_prop(self.blinder_index as <PSBT_ELEMENTS_OUT_BLINDER_INDEX.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.blind_value_proof as <PSBT_ELEMENTS_OUT_BLIND_VALUE_PROOF, _>)
+            rv.push_prop(self.blind_value_proof as <PSBT_ELEMENTS_OUT_BLIND_VALUE_PROOF.into(), _>)
         }
 
         impl_pset_get_pair! {
-            rv.push_prop(self.blind_asset_proof as <PSBT_ELEMENTS_OUT_BLIND_ASSET_PROOF, _>)
+            rv.push_prop(self.blind_asset_proof as <PSBT_ELEMENTS_OUT_BLIND_ASSET_PROOF.into(), _>)
         }
 
         for (key, value) in self.proprietary.iter() {


### PR DESCRIPTION
Before this commit only u8 is available as ProprietaryType, to support ELIP100 this value has to be treated like a VarInt. This is the minimal change needed to support that while remaining compatible.

Missing test and other things

Needed for https://github.com/ElementsProject/rust-elements/pull/180