### PR TITLE
elip100: add missing AssetMetadata::new method

### DIFF
--- a/src/pset/elip100.rs
+++ b/src/pset/elip100.rs
@@ -76,6 +76,12 @@ fn prop_key(asset_id: &AssetId) -> ProprietaryKey {
 }
 
 impl AssetMetadata {
+
+    /// Create a new [`AssetMetadata`]
+    pub fn new(contract: String, issuance_prevout: OutPoint) -> Self {
+        Self { contract, issuance_prevout }
+    }
+
     /// Returns the contract as string containing a json
     pub fn contract(&self) -> &str {
         &self.contract


### PR DESCRIPTION
Missing from #182  otherwise there is no way to instantiate `AssetMetadata` and call `add_asset_metadata` 