### PR TITLE
Fix: typos in docs

### DIFF
--- a/examples/pset_blind_coinjoin.rs
+++ b/examples/pset_blind_coinjoin.rs
@@ -31,7 +31,7 @@ use elements::hex::FromHex;
 use rand::SeedableRng;
 
 // Assume txouts are simple pay to wpkh
-// and keep the secrets correponding to
+// and keep the secrets corresponding to
 // confidential txouts
 #[derive(Debug, Clone)]
 struct Secrets {

--- a/examples/raw_blind.rs
+++ b/examples/raw_blind.rs
@@ -27,7 +27,7 @@ use rand::SeedableRng;
 static PARAMS: AddressParams = AddressParams::ELEMENTS;
 
 // Assume txouts are simple pay to wpkh
-// and keep the secrets correponding to
+// and keep the secrets corresponding to
 // confidential txouts
 #[derive(Debug, Clone)]
 struct Secrets {

--- a/src/blind.rs
+++ b/src/blind.rs
@@ -924,7 +924,7 @@ impl Transaction {
     /// Verify that the transaction has correctly calculated blinding
     /// factors and they CT verification equation holds.
     /// This is *NOT* a complete Transaction verification check
-    /// It does *NOT* check whether input witness/script satifies
+    /// It does *NOT* check whether input witness/script satisfies
     /// the script pubkey, or inputs are double-spent and other
     /// consensus checks.
     /// This method only checks if the [Transaction] verification

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -198,7 +198,7 @@ impl Decodable for FullParams {
     }
 }
 
-/// Dynamic federations paramaters, as encoded in a block header
+/// Dynamic federations parameters, as encoded in a block header
 #[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Params {
     /// Null entry, used to signal "no vote" as a proposal

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -199,7 +199,7 @@ impl ToHex for [u8] {
 /// but if you have an encodable object, by using this you avoid the
 /// serialization to `Vec<u8>` by going directly to `String`.
 ///
-/// Note that to achieve better perfomance than [`ToHex`] the struct must be
+/// Note that to achieve better performance than [`ToHex`] the struct must be
 /// created with the right `capacity` of the final hex string so that the inner
 /// `String` doesn't re-allocate.
 pub struct HexWriter(String);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -52,7 +52,7 @@ impl fmt::Display for ParseIntError {
     }
 }
 
-/// Not strictly neccessary but serves as a lint - avoids weird behavior if someone accidentally
+/// Not strictly necessary but serves as a lint - avoids weird behavior if someone accidentally
 /// passes non-integer to the `parse()` function.
 pub(crate) trait Integer: FromStr<Err=std::num::ParseIntError> + TryFrom<i8> + Sized {}
 

--- a/src/pset/elip100.rs
+++ b/src/pset/elip100.rs
@@ -252,7 +252,7 @@ mod test {
             .get_pairs()
             .unwrap()
             .into_iter()
-            .filter(|p| serialize(&p.key)[1..] == expected_key[..]) // NOTE key serialization contains an initial varint with the lenght of the key which is not present in the test vector
+            .filter(|p| serialize(&p.key)[1..] == expected_key[..]) // NOTE key serialization contains an initial varint with the length of the key which is not present in the test vector
             .map(|p| p.value)
             .collect();
         assert_eq!(values.len(), 1);

--- a/src/pset/error.rs
+++ b/src/pset/error.rs
@@ -68,7 +68,7 @@ pub enum Error {
     NonStandardSighashType(u32),
     /// Parsing errors from bitcoin_hashes
     HashParseError(hashes::FromSliceError),
-    /// The pre-image must hash to the correponding pset hash
+    /// The pre-image must hash to the corresponding pset hash
     InvalidPreimageHashPair {
         /// Hash-type
         hash_type: PsetHash,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -212,7 +212,7 @@ impl Sequence {
     /// BIP-68 relative lock-time type flag mask
     const LOCK_TYPE_MASK: u32 = 0x00400000;
 
-    /// Retuns `true` if the sequence number indicates that the transaction is finalised.
+    /// Returns `true` if the sequence number indicates that the transaction is finalised.
     ///
     /// The sequence number being equal to 0xffffffff on all txin sequences indicates
     /// that the transaction is finalised.
@@ -415,7 +415,7 @@ pub struct PeginData<'tx> {
     /// to feed it raw into a hash function.
     pub claim_script: &'tx [u8],
     /// Mainchain transaction; not parsed to save time/memory since the
-    /// parsed transaction is typically not useful without auxillary
+    /// parsed transaction is typically not useful without auxiliary
     /// data (e.g. knowing how to compute pegin addresses for the
     /// sidechain).
     pub tx: &'tx [u8],


### PR DESCRIPTION
examples: fix typos in docs
src: fix typos in docs