### PR TITLE
add `Address::is_liquid`

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -223,6 +223,11 @@ impl Address {
         self.blinding_pubkey.is_some()
     }
 
+    /// Return if the address is for the Liquid network
+    pub fn is_liquid(&self) -> bool {
+        self.params == &AddressParams::LIQUID
+    }
+
     /// Creates a pay to (compressed) public key hash address from a public key
     /// This is the preferred non-witness type address
     #[inline]


### PR DESCRIPTION
User code can already compare against AddressParams, but it seems easier to find a method to check if the address is liquid. Even tough is less general because you can't discriminate between elements and liquid testnet, most of the time wallets are interested only in the mainnet or not discrimination.