### PR TITLE
ci: fixes for rust stable clippy, and rust 1.56.1 compilation

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -9,6 +9,7 @@ if cargo --version | grep "1\.56"; then
     cargo update -p which --precise 4.4.0
     cargo update -p byteorder --precise 1.4.3
     cargo update -p cc --precise 1.0.94
+    cargo update -p libc --precise 0.2.163
     cargo update -p serde_json --precise 1.0.98
     cargo update -p serde --precise 1.0.156
     cargo update -p ppv-lite86 --precise 0.2.8

--- a/src/blech32/decode.rs
+++ b/src/blech32/decode.rs
@@ -439,7 +439,7 @@ pub struct ByteIter<'s> {
     iter: FesToBytes<AsciiToFe32Iter<iter::Copied<slice::Iter<'s, u8>>>>,
 }
 
-impl<'s> Iterator for ByteIter<'s> {
+impl Iterator for ByteIter<'_> {
     type Item = u8;
     #[inline]
     fn next(&mut self) -> Option<u8> { self.iter.next() }
@@ -447,7 +447,7 @@ impl<'s> Iterator for ByteIter<'s> {
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
-impl<'s> ExactSizeIterator for ByteIter<'s> {
+impl ExactSizeIterator for ByteIter<'_> {
     #[inline]
     fn len(&self) -> usize { self.iter.len() }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for ExtData {
         enum Enum { Unknown, Challenge, Solution, Current, Proposed, Witness }
         struct EnumVisitor;
 
-        impl<'de> de::Visitor<'de> for EnumVisitor {
+        impl de::Visitor<'_> for EnumVisitor {
             type Value = Enum;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -816,7 +816,7 @@ impl<'de> Deserialize<'de> for AssetBlindingFactor {
         if d.is_human_readable() {
             struct HexVisitor;
 
-            impl<'de> ::serde::de::Visitor<'de> for HexVisitor {
+            impl ::serde::de::Visitor<'_> for HexVisitor {
                 type Value = AssetBlindingFactor;
 
                 fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -830,7 +830,7 @@ impl<'de> Deserialize<'de> for AssetBlindingFactor {
                     if let Ok(hex) = ::std::str::from_utf8(v) {
                         AssetBlindingFactor::from_hex(hex).map_err(E::custom)
                     } else {
-                        return Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self));
+                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
                     }
                 }
 
@@ -846,7 +846,7 @@ impl<'de> Deserialize<'de> for AssetBlindingFactor {
         } else {
             struct BytesVisitor;
 
-            impl<'de> ::serde::de::Visitor<'de> for BytesVisitor {
+            impl ::serde::de::Visitor<'_> for BytesVisitor {
                 type Value = AssetBlindingFactor;
 
                 fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -1019,7 +1019,7 @@ impl<'de> Deserialize<'de> for ValueBlindingFactor {
         if d.is_human_readable() {
             struct HexVisitor;
 
-            impl<'de> ::serde::de::Visitor<'de> for HexVisitor {
+            impl ::serde::de::Visitor<'_> for HexVisitor {
                 type Value = ValueBlindingFactor;
 
                 fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -1033,7 +1033,7 @@ impl<'de> Deserialize<'de> for ValueBlindingFactor {
                     if let Ok(hex) = ::std::str::from_utf8(v) {
                         ValueBlindingFactor::from_hex(hex).map_err(E::custom)
                     } else {
-                        return Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self));
+                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
                     }
                 }
 
@@ -1049,7 +1049,7 @@ impl<'de> Deserialize<'de> for ValueBlindingFactor {
         } else {
             struct BytesVisitor;
 
-            impl<'de> ::serde::de::Visitor<'de> for BytesVisitor {
+            impl ::serde::de::Visitor<'_> for BytesVisitor {
                 type Value = ValueBlindingFactor;
 
                 fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -27,18 +27,18 @@ use crate::Script;
 
 /// ad-hoc struct to fmt in hex
 struct HexBytes<'a>(&'a [u8]);
-impl<'a> fmt::Display for HexBytes<'a> {
+impl fmt::Display for HexBytes<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         crate::hex::format_hex(self.0, f)
     }
 }
-impl<'a> fmt::Debug for HexBytes<'a> {
+impl fmt::Debug for HexBytes<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self, f)
     }
 }
 #[cfg(feature = "serde")]
-impl<'a> Serialize for HexBytes<'a> {
+impl Serialize for HexBytes<'_> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         if s.is_human_readable() {
             s.collect_str(self)
@@ -50,7 +50,7 @@ impl<'a> Serialize for HexBytes<'a> {
 
 /// ad-hoc struct to fmt in hex
 struct HexBytesArray<'a>(&'a [Vec<u8>]);
-impl<'a> fmt::Display for HexBytesArray<'a> {
+impl fmt::Display for HexBytesArray<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[")?;
         for (i, e) in self.0.iter().enumerate() {
@@ -62,13 +62,13 @@ impl<'a> fmt::Display for HexBytesArray<'a> {
         write!(f, "]")
     }
 }
-impl<'a> fmt::Debug for HexBytesArray<'a> {
+impl fmt::Debug for HexBytesArray<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self, f)
     }
 }
 #[cfg(feature = "serde")]
-impl<'a> Serialize for HexBytesArray<'a> {
+impl Serialize for HexBytesArray<'_> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         let mut seq = s.serialize_seq(Some(self.0.len()))?;
         for b in self.0 {
@@ -420,7 +420,7 @@ impl<'de> Deserialize<'de> for Params {
         }
         struct EnumVisitor;
 
-        impl<'de> de::Visitor<'de> for EnumVisitor {
+        impl de::Visitor<'_> for EnumVisitor {
             type Value = Enum;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -104,7 +104,7 @@ fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
     Ok(ret as u8)
 }
 
-impl<'a> Iterator for HexIterator<'a> {
+impl Iterator for HexIterator<'_> {
     type Item = Result<u8, Error>;
 
     fn next(&mut self) -> Option<Result<u8, Error>> {
@@ -119,7 +119,7 @@ impl<'a> Iterator for HexIterator<'a> {
     }
 }
 
-impl<'a> io::Read for HexIterator<'a> {
+impl io::Read for HexIterator<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut bytes_read = 0usize;
         for dst in buf {
@@ -135,7 +135,7 @@ impl<'a> io::Read for HexIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for HexIterator<'a> {
+impl DoubleEndedIterator for HexIterator<'_> {
     fn next_back(&mut self) -> Option<Result<u8, Error>> {
         let lo = self.iter.next_back()?;
         let hi = self.iter.next_back().unwrap();
@@ -143,7 +143,7 @@ impl<'a> DoubleEndedIterator for HexIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for HexIterator<'a> {}
+impl ExactSizeIterator for HexIterator<'_> {}
 
 /// Outputs hex into an object implementing `fmt::Write`.
 ///

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -203,7 +203,7 @@ impl<'de> ::serde::Deserialize<'de> for AssetId {
         if d.is_human_readable() {
             struct HexVisitor;
 
-            impl<'de> ::serde::de::Visitor<'de> for HexVisitor {
+            impl ::serde::de::Visitor<'_> for HexVisitor {
                 type Value = AssetId;
 
                 fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -217,7 +217,7 @@ impl<'de> ::serde::Deserialize<'de> for AssetId {
                     if let Ok(hex) = ::std::str::from_utf8(v) {
                         AssetId::from_str(hex).map_err(E::custom)
                     } else {
-                        return Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self));
+                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
                     }
                 }
 
@@ -233,7 +233,7 @@ impl<'de> ::serde::Deserialize<'de> for AssetId {
         } else {
             struct BytesVisitor;
 
-            impl<'de> ::serde::de::Visitor<'de> for BytesVisitor {
+            impl ::serde::de::Visitor<'_> for BytesVisitor {
                 type Value = AssetId;
 
                 fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -242,7 +242,7 @@ pub mod hex_bytes {
     {
         struct Visitor<B>(::std::marker::PhantomData<B>);
 
-        impl<'de, B: FromHex> serde::de::Visitor<'de> for Visitor<B> {
+        impl<B: FromHex> serde::de::Visitor<'_> for Visitor<B> {
             type Value = B;
 
             fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -255,7 +255,7 @@ pub mod hex_bytes {
                 if let Ok(hex) = ::std::str::from_utf8(v) {
                     FromHex::from_hex(hex).map_err(E::custom)
                 } else {
-                    return Err(E::invalid_value(serde::de::Unexpected::Bytes(v), &self));
+                    Err(E::invalid_value(serde::de::Unexpected::Bytes(v), &self))
                 }
             }
 

--- a/src/sighash.rs
+++ b/src/sighash.rs
@@ -167,7 +167,7 @@ impl fmt::Display for Error {
 
 impl ::std::error::Error for Error {}
 
-impl<'u, T> Prevouts<'u, T> where T: Borrow<TxOut> {
+impl<T> Prevouts<'_, T> where T: Borrow<TxOut> {
     fn check_all(&self, tx: &Transaction) -> Result<(), Error> {
         if let Prevouts::All(prevouts) = self {
             if prevouts.len() != tx.input.len() {
@@ -866,7 +866,7 @@ impl<'a> Annex<'a> {
     }
 }
 
-impl<'a> Encodable for Annex<'a> {
+impl Encodable for Annex<'_> {
     fn consensus_encode<W: io::Write>(&self, writer: W) -> Result<usize, encode::Error> {
         encode::consensus_encode_with_size(self.0, writer)
     }


### PR DESCRIPTION
Fixes clippy for the stable CI job, and pins libc to 0.2.163 for the rust 1.56.1 job 