### PR TITLE
pset: input: insert non-pset proprietary keys

### DIFF
--- a/src/pset/elip101.rs
+++ b/src/pset/elip101.rs
@@ -134,8 +134,7 @@ mod test {
         let bytes = encode::serialize(&pset);
         let pset_back = encode::deserialize::<PartiallySignedTransaction>(&bytes).unwrap();
         // Check the abf
-        // FIXME: input abf should be there
-        assert!(pset_back.inputs()[0].get_abf().is_none());
+        assert_eq!(pset_back.inputs()[0].get_abf().unwrap().unwrap(), abf);
         assert_eq!(pset_back.outputs()[0].get_abf().unwrap().unwrap(), abf);
     }
 }

--- a/src/pset/map/input.rs
+++ b/src/pset/map/input.rs
@@ -759,8 +759,18 @@ impl Map for Input {
                             Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key).into()),
                         },
                     }
+                } else {
+                    match self.proprietary.entry(prop_key) {
+                        Entry::Vacant(empty_key) => {
+                            empty_key.insert(raw_value);
+                        }
+                        Entry::Occupied(_) => {
+                            return Err(Error::DuplicateKey(raw_key).into())
+                        }
+                    }
                 }
             }
+
             _ => match self.unknown.entry(raw_key) {
                 Entry::Vacant(empty_key) => {
                     empty_key.insert(raw_value);


### PR DESCRIPTION
As it is done for pset outputs.