### PR TITLE
Make AssetId::from_inner a const function

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -76,7 +76,7 @@ impl AssetId {
     ]));
 
     /// Create an [AssetId] from its inner type.
-    pub fn from_inner(midstate: sha256::Midstate) -> AssetId {
+    pub const fn from_inner(midstate: sha256::Midstate) -> AssetId {
         AssetId(midstate)
     }
 


### PR DESCRIPTION
This will allow constructing `AssetId` values like this:
```
const TESTNET_ASSET: elemets::AssetId = const_asset_id("144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49");

/// Panics if the asset id string has wrong length or format
pub const fn const_asset_id(s: &str) -> elements::AssetId {
    let mut data: [u8; 32] = hex_literal::decode::<32>(&[s.as_bytes()]);

    let mut left = 0;
    let mut right = data.len() - 1;
    while left < right {
        let tmp = data[left];
        data[left] = data[right];
        data[right] = tmp;
        left += 1;
        right -= 1;
    }

    elements::AssetId::from_inner(bitcoin::hashes::sha256::Midstate(data))
}
```

It's a bit of a hack because `hex_literal::decode` should not be used directly.