### PR TITLE
bump version 0.25.1 -> 0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+# 0.25.2 - 2025-04-18
+
+* [https://github.com/ElementsProject/rust-elements/pull/226](elip102: rename from elip101)
+* [https://github.com/ElementsProject/rust-elements/pull/225](Make AssetId::from_inner a const function)
+* [https://github.com/ElementsProject/rust-elements/pull/224](pset: input: insert non-pset proprietary keys)
+* [https://github.com/ElementsProject/rust-elements/pull/223](clippy: fix for new rust stable)
+* [https://github.com/ElementsProject/rust-elements/pull/195](Fix WASM build and add a job in CI)
+* [https://github.com/ElementsProject/rust-elements/pull/222](elementsd-tests: blind asset issuance based on node version)
+* [https://github.com/ElementsProject/rust-elements/pull/220](tx: discountct: add missing testcase)
+* [https://github.com/ElementsProject/rust-elements/pull/221](ci: fixes for rust stable clippy, and rust 1.56.1 compilation)
+
 # 0.25.1 - 2024-10-24
 
 * [https://github.com/ElementsProject/rust-elements/pull/218](discount: fix weight calculation)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elements"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Andrew Poelstra <apoelstra@blockstream.com>"]
 description = "Library with support for de/serialization, parsing and executing on data structures and network messages related to Elements"
 license = "CC0-1.0"


### PR DESCRIPTION
The elip rename is a breaking change, but it's highly likely we are the only one using it and a patch release would allow us to avoid the deps release dance