### PR TITLE
pset: blind: return ephemeral private key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use bitcoin::hashes;
 pub use crate::address::{Address, AddressError, AddressParams};
 pub use crate::blind::{
     BlindAssetProofs, BlindError, BlindValueProofs, ConfidentialTxOutError, RangeProofMessage,
-    SurjectionInput, TxOutError, TxOutSecrets, UnblindError, VerificationError,
+    SurjectionInput, TxOutError, TxOutSecrets, UnblindError, VerificationError, TxInType,
 };
 pub use crate::block::ExtData as BlockExtData;
 pub use crate::block::{Block, BlockHeader};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use bitcoin::hashes;
 pub use crate::address::{Address, AddressError, AddressParams};
 pub use crate::blind::{
     BlindAssetProofs, BlindError, BlindValueProofs, ConfidentialTxOutError, RangeProofMessage,
-    SurjectionInput, TxOutError, TxOutSecrets, UnblindError, VerificationError, TxInType,
+    SurjectionInput, TxOutError, TxOutSecrets, UnblindError, VerificationError, CtLocation, CtLocationType,
 };
 pub use crate::block::ExtData as BlockExtData;
 pub use crate::block::{Block, BlockHeader};

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -579,9 +579,10 @@ impl PartiallySignedTransaction {
         rng: &mut R,
         secp: &secp256k1_zkp::Secp256k1<C>,
         inp_txout_sec: &HashMap<usize, TxOutSecrets>,
-    ) -> Result<(), PsetBlindError> {
+    ) -> Result<Vec<(AssetBlindingFactor, ValueBlindingFactor, SecretKey)>, PsetBlindError> {
         let (mut inp_secrets, mut outs_to_blind) = self.blind_checks(inp_txout_sec)?;
 
+        let mut ret = vec![];
         if outs_to_blind.is_empty() {
             // Atleast one output must be marked for blinding for pset blind_last
             return Err(PsetBlindError::AtleastOneOutputBlind);
@@ -594,7 +595,7 @@ impl PartiallySignedTransaction {
             let ind = self.outputs[last_out_index].blinder_index;
             self.outputs[last_out_index].blinder_index = None;
             // Blind normally without the last index
-            self.blind_non_last(rng, secp, inp_txout_sec)?;
+            ret = self.blind_non_last(rng, secp, inp_txout_sec)?;
             // Restore who blinded the last output
             self.outputs[last_out_index].blinder_index = ind;
             // inp_secrets contributed to self.global.scalars, unset it so we don't count them
@@ -657,6 +658,7 @@ impl PartiallySignedTransaction {
         );
         let (value_commitment, nonce, rangeproof) =
             blind_res.map_err(|e| PsetBlindError::ConfidentialTxOutError(last_out_index, e))?;
+        ret.push((out_abf, final_vbf, ephemeral_sk));
 
         // mutate the pset
         {
@@ -690,7 +692,7 @@ impl PartiallySignedTransaction {
 
             self.global.scalars.clear();
         }
-        Ok(())
+        Ok(ret)
     }
 }
 

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -478,7 +478,7 @@ impl PartiallySignedTransaction {
         rng: &mut R,
         secp: &secp256k1_zkp::Secp256k1<C>,
         inp_txout_sec: &HashMap<usize, TxOutSecrets>,
-    ) -> Result<Vec<(AssetBlindingFactor, ValueBlindingFactor)>, PsetBlindError> {
+    ) -> Result<Vec<(AssetBlindingFactor, ValueBlindingFactor, SecretKey)>, PsetBlindError> {
         let (inp_secrets, outs_to_blind) = self.blind_checks(inp_txout_sec)?;
 
         if outs_to_blind.is_empty() {
@@ -491,7 +491,7 @@ impl PartiallySignedTransaction {
         let mut ret = vec![]; // return all the random values used
         for i in outs_to_blind {
             let txout = self.outputs[i].to_txout();
-            let (txout, abf, vbf, _) = txout
+            let (txout, abf, vbf, ephemeral_sk) = txout
                 .to_non_last_confidential(
                     rng,
                     secp,
@@ -538,7 +538,7 @@ impl PartiallySignedTransaction {
                 ));
             }
             // return blinding factors used
-            ret.push((abf, vbf));
+            ret.push((abf, vbf, ephemeral_sk));
         }
 
         // safe to unwrap because we have checked that there is atleast one output to blind


### PR DESCRIPTION
Right now we have:
* `Transaction::blind` returns abf, vbf and ephemeral private key
* `PartiallySignedTransaction::blind_non_last` returns abf and vbf
* `PartiallySignedTransaction::blind_last` returns nothing

This PR makes things more consistent and makes ephemeral keys more easily accessible.

It's a breaking change, but it's just augmenting the data, so it should be easy to handle downstream.