### PR TITLE
ci: reduce nightly version update from semiweekly to weekly

### DIFF
--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -1,7 +1,7 @@
 name: Update Nightly rustc
 on:
   schedule:
-    - cron: "5 0 * * 1,4" # runs every Monday and Thursday at 00:05 UTC
+    - cron: "5 0 * * 1" # runs every Monday at 00:05 UTC
   workflow_dispatch: # allows manual triggering
 jobs:
   format:


### PR DESCRIPTION
Turns out it's hard with GA to do things every other week (or every four weeks). But it's easy to at least stop doing it twice every week!

Reduces the noise from the nightly-update PRs by half.