### PR TITLE
Release 0.26.1 with some minor API extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+# 0.26.1 - 2025-08-28
+
+* [#250](https://github.com/ElementsProject/rust-elements/pull/250) API cleanups
+  * implement `Encodable` and `Decodable` for `Vec<T>` whenever `T` is `Encodable`/`Decodable` and `'static`
+  * add missing export of error sub-type `pset::PsetHash`
+
 # 0.26.0 - 2025-08-22
 
 * [#249](https://github.com/ElementsProject/rust-elements/pull/249) docs: fix changelog links

--- a/Cargo-latest.lock
+++ b/Cargo-latest.lock
@@ -190,7 +190,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elements"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bech32",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elements"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Andrew Poelstra <apoelstra@blockstream.com>"]
 description = "Library with support for de/serialization, parsing and executing on data structures and network messages related to Elements"
 license = "CC0-1.0"

--- a/src/pset/error.rs
+++ b/src/pset/error.rs
@@ -26,9 +26,13 @@ use secp256k1_zkp;
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 /// Enum for marking pset hash error
 pub enum PsetHash {
+    /// Bad preimage for `RIPEMD160` hash.
     Ripemd,
+    /// Bad preimage for `SHA256` hash.
     Sha256,
+    /// Bad preimage for `RIPEMD160-SHA256` hash.
     Hash160,
+    /// Bad preimage for double-`SHA256` hash.
     Hash256,
 }
 /// Ways that a Partially Signed Transaction might fail.

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -53,7 +53,7 @@ use crate::{
 use secp256k1_zkp::rand::{CryptoRng, RngCore};
 use secp256k1_zkp::{self, RangeProof, SecretKey, SurjectionProof};
 
-pub use self::error::{Error, PsetBlindError};
+pub use self::error::{Error, PsetBlindError, PsetHash};
 use self::map::Map;
 pub use self::map::{Global, GlobalTxData, Input, Output, PsbtSighashType, TapTree};
 


### PR DESCRIPTION
I want to do the dtolnay "semver trick" where I release 0.25.3 which re-exports most of the types and traits from 0.26. This will make migration easier for users since they could use elements 0.25 and 0.26 in the same crate and have compatible types. In particular https://github.com/ElementsProject/elements-miniscript/pull/97 would compile without needing to update `simplicity` and `elements` at the same time.

However, when doing this I identified some gaps in the API which make this harder than it should be. See the commit messages for detailed justifications.

Also release 0.26.1 with these changes.