### PR TITLE
Replace custom hex parsing with hex-conservative crate 

### DIFF
--- a/Cargo-latest.lock
+++ b/Cargo-latest.lock
@@ -64,7 +64,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative",
+ "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1",
  "serde",
@@ -108,7 +108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
@@ -196,6 +196,7 @@ dependencies = [
  "bincode",
  "bitcoin",
  "getrandom 0.2.16",
+ "hex-conservative 1.0.0",
  "rand",
  "rand_chacha",
  "secp256k1-zkp",
@@ -273,6 +274,12 @@ checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-conservative"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee770c000993d17c185713463d5ebfbd1af9afae4c17cc295640104383bfbf0"
 
 [[package]]
 name = "hex_lit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = { version = "1.0", optional = true }
 actual-serde = { package = "serde", version = "1.0.103", features = [
     "derive",
 ], optional = true }
+hex-conservative = "1.0.0"
 
 
 [target.wasm32-unknown-unknown.dev-dependencies]

--- a/src/script.rs
+++ b/src/script.rs
@@ -27,6 +27,7 @@
 use std::default::Default;
 use std::{fmt, io, ops, str};
 
+use hex_conservative::DecodeVariableLengthBytesError;
 use secp256k1_zkp::{Verification, Secp256k1};
 #[cfg(feature = "serde")] use serde;
 
@@ -78,17 +79,17 @@ impl fmt::UpperHex for Script {
 }
 
 impl hex::FromHex for Script {
-    fn from_byte_iter<I>(iter: I) -> Result<Self, hex::Error>
-        where I: Iterator<Item=Result<u8, hex::Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator,
-    {
-        Vec::from_byte_iter(iter).map(|v| Script(Box::<[u8]>::from(v)))
+    type Err = DecodeVariableLengthBytesError;
+
+    fn from_hex(s: &str) -> Result<Self, Self::Err> {
+        hex_conservative::decode_to_vec(s).map(|v| Script(Box::<[u8]>::from(v)))
     }
 }
+
 impl str::FromStr for Script {
-    type Err = hex::Error;
-    fn from_str(s: &str) -> Result<Self, hex::Error> {
+    type Err = <Self as hex::FromHex>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         hex::FromHex::from_hex(s)
     }
 }

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -238,11 +238,16 @@ pub mod hex_bytes {
     }
 
     pub fn deserialize<'de, D, B>(d: D) -> Result<B, D::Error>
-        where D: serde::Deserializer<'de>, B: serde::Deserialize<'de> + FromHex,
+        where D: serde::Deserializer<'de>,
+              B: serde::Deserialize<'de> + FromHex,
+              <B as FromHex>::Err: std::fmt::Display,
     {
         struct Visitor<B>(::std::marker::PhantomData<B>);
 
-        impl<B: FromHex> serde::de::Visitor<'_> for Visitor<B> {
+        impl<B: FromHex> serde::de::Visitor<'_> for Visitor<B>
+        where
+            <B as FromHex>::Err: std::fmt::Display,
+        {
             type Value = B;
 
             fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {


### PR DESCRIPTION
# Overview

Add hex-conservative as a dependency and refactor hex parsing code to use it instead of the custom implementation. Update FromHex trait to use associated error types and standardize hex decoding across the codebase.

Closes: #258 