### PR TITLE
bump MSRV to 1.74.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/ElementsProject/rust-elements/"
 repository = "https://github.com/ElementsProject/rust-elements/"
 documentation = "https://docs.rs/elements/"
 edition = "2018"
-rust-version = "1.63.0"
+rust-version = "1.74.0"
 
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-04-17"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ structures and network messages related to Elements
 
 [Documentation](https://docs.rs/elements/)
 
-
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features on **Rust 1.48.0**.
+This library should always compile with any combination of features on **Rust 1.74.0**.

--- a/elementsd-tests/Cargo.toml
+++ b/elementsd-tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "elementsd-tests"
 version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 edition = "2018"
-rust-version = "1.63.0"
+rust-version = "1.74.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/blind.rs
+++ b/src/blind.rs
@@ -740,9 +740,8 @@ impl TxOut {
         secp: &Secp256k1<C>,
         blinding_key: SecretKey,
     ) -> Result<TxOutSecrets, UnblindError> {
-        let (commitment, additional_generator) = match (self.value, self.asset) {
-            (Value::Confidential(com), Asset::Confidential(gen)) => (com, gen),
-            _ => return Err(UnblindError::NotConfidential),
+        let (Value::Confidential(commitment), Asset::Confidential(additional_generator)) = (self.value, self.asset) else {
+            return Err(UnblindError::NotConfidential);
         };
 
         let shared_secret = self

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -110,9 +110,8 @@ macro_rules! serde_struct_impl {
                         }
 
                         $(
-                            let $fe = match $fe {
-                                Some(x) => x,
-                                None => return Err(A::Error::missing_field(stringify!($fe))),
+                            let Some($fe) = $fe else {
+                                return Err(A::Error::missing_field(stringify!($fe)));
                             };
                         )*
 
@@ -348,9 +347,8 @@ macro_rules! serde_struct_human_string_impl {
                             }
 
                             $(
-                                let $fe = match $fe {
-                                    Some(x) => x,
-                                    None => return Err(A::Error::missing_field(stringify!($fe))),
+                                let Some($fe) = $fe else {
+                                    return Err(A::Error::missing_field(stringify!($fe)));
                                 };
                             )*
 

--- a/src/pset/serialize.rs
+++ b/src/pset/serialize.rs
@@ -176,9 +176,8 @@ impl Serialize for KeySource {
 
 impl Deserialize for KeySource {
     fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
-        let prefix = match <[u8; 4]>::try_from(&bytes[0..4]) {
-            Ok(prefix) => prefix,
-            Err(_) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into()),
+        let Ok(prefix) = <[u8; 4]>::try_from(&bytes[0..4]) else {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into());
         };
 
         let fprint: Fingerprint = Fingerprint::from(prefix);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -281,7 +281,7 @@ impl Sequence {
     /// Will return an error if the input cannot be encoded in 16 bits.
     #[inline]
     pub fn from_seconds_ceil(seconds: u32) -> Result<Self, RelativeLockTimeError> {
-        if let Ok(interval) = u16::try_from((seconds + 511) / 512) {
+        if let Ok(interval) = u16::try_from(seconds.div_ceil(512)) {
             Ok(Sequence::from_512_second_intervals(interval))
         } else {
             Err(RelativeLockTimeError::IntegerOverflow(seconds))
@@ -927,7 +927,7 @@ impl Transaction {
     #[inline]
     pub fn vsize(&self) -> usize {
         let weight = self.weight();
-        (weight + 4 - 1) / 4
+        weight.div_ceil(4)
     }
 
     /// Get the "discount weight" of this transaction; this is the weight minus the output witnesses and minus the
@@ -955,7 +955,7 @@ impl Transaction {
     ///
     /// Will be `ceil(discount weight / 4.0)`.
     pub fn discount_vsize(&self) -> usize {
-        (self.discount_weight() + 4 - 1) / 4
+        self.discount_weight().div_ceil(4)
     }
 
     fn scaled_size(&self, scale_factor: usize) -> usize {


### PR DESCRIPTION
This matches the rust-bitcoin ecosystem, and in particular bitcoin-consensus-encoding which we hope to replace our homebrew encoding traits with. This MSRV is also needed to use libfuzzer, which is used by cargo-fuzz.

lwk and rust-simplicity both have higher MSRVs so there seems to be little point here in having a very old one.