### PR TITLE
Clean up hashes and related types ahead of `bitcoin_hashes` 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ default = ["json-contract"]
 
 json-contract = ["serde_json"]
 "serde" = [
+    "dep:serde",
     "bitcoin/serde",
     "bitcoin/serde",
     "secp256k1-zkp/serde",
-    "actual-serde",
 ]
 base64 = ["bitcoin/base64"]
 
@@ -33,10 +33,7 @@ secp256k1-zkp = { version = "0.11.0", features = ["global-context", "hashes"] }
 
 # Used for ContractHash::from_json_contract.
 serde_json = { version = "1.0", optional = true }
-
-actual-serde = { package = "serde", version = "1.0.103", features = [
-    "derive",
-], optional = true }
+serde = { version = "1.0.103", features = [ "derive" ], optional = true }
 hex = { package = "hex-conservative", version = "1.1.0" }
 
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -36,7 +36,7 @@ use crate::schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 use crate::taproot::TapNodeHash;
 
 use crate::{opcodes, script};
-use crate::{PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash};
+use crate::{PubkeyHash, ScriptHash, WScriptHash};
 
 /// Encoding error
 #[derive(Debug, PartialEq)]
@@ -236,13 +236,9 @@ impl Address {
         blinder: Option<secp256k1_zkp::PublicKey>,
         params: &'static AddressParams,
     ) -> Address {
-        let mut hash_engine = PubkeyHash::engine();
-        pk.write_into(&mut hash_engine)
-            .expect("engines don't error");
-
         Address {
             params,
-            payload: Payload::PubkeyHash(PubkeyHash::from_engine(hash_engine)),
+            payload: Payload::PubkeyHash(pk.pubkey_hash()),
             blinding_pubkey: blinder,
         }
     }
@@ -264,20 +260,20 @@ impl Address {
 
     /// Create a witness pay to public key address from a public key
     /// This is the native segwit address type for an output redeemable with a single signature
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided public key is not compressed.
     pub fn p2wpkh(
         pk: &PublicKey,
         blinder: Option<secp256k1_zkp::PublicKey>,
         params: &'static AddressParams,
     ) -> Address {
-        let mut hash_engine = WPubkeyHash::engine();
-        pk.write_into(&mut hash_engine)
-            .expect("engines don't error");
-
         Address {
             params,
             payload: Payload::WitnessProgram {
                 version: Fe32::Q,
-                program: WPubkeyHash::from_engine(hash_engine)[..].to_vec(),
+                program: pk.wpubkey_hash().expect("public key must be compressed").as_byte_array().to_vec(),
             },
             blinding_pubkey: blinder,
         }

--- a/src/address.rs
+++ b/src/address.rs
@@ -253,7 +253,7 @@ impl Address {
     ) -> Address {
         Address {
             params,
-            payload: Payload::ScriptHash(ScriptHash::hash(&script[..])),
+            payload: Payload::ScriptHash(ScriptHash::hash_script(script)),
             blinding_pubkey: blinder,
         }
     }
@@ -281,22 +281,23 @@ impl Address {
 
     /// Create a pay to script address that embeds a witness pay to public key
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided public key is not compressed.
     pub fn p2shwpkh(
         pk: &PublicKey,
         blinder: Option<secp256k1_zkp::PublicKey>,
         params: &'static AddressParams,
     ) -> Address {
-        let mut hash_engine = ScriptHash::engine();
-        pk.write_into(&mut hash_engine)
-            .expect("engines don't error");
-
+        let pkh = pk.wpubkey_hash().expect("public key must be compressed");
         let builder = script::Builder::new()
             .push_int(0)
-            .push_slice(&ScriptHash::from_engine(hash_engine)[..]);
+            .push_slice(pkh.as_ref());
 
         Address {
             params,
-            payload: Payload::ScriptHash(ScriptHash::hash(builder.into_script().as_bytes())),
+            payload: Payload::ScriptHash(ScriptHash::hash_script(&builder.into_script())),
             blinding_pubkey: blinder,
         }
     }
@@ -311,7 +312,7 @@ impl Address {
             params,
             payload: Payload::WitnessProgram {
                 version: Fe32::Q,
-                program: WScriptHash::hash(&script[..])[..].to_vec(),
+                program: WScriptHash::hash_script(script).as_byte_array().to_vec(),
             },
             blinding_pubkey: blinder,
         }

--- a/src/blind.rs
+++ b/src/blind.rs
@@ -224,8 +224,7 @@ impl RangeProofMessage {
 /// Information about Transaction Input Asset
 #[cfg_attr(
     feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "actual_serde")
+    derive(serde::Serialize, serde::Deserialize),
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct TxOutSecrets {

--- a/src/blind.rs
+++ b/src/blind.rs
@@ -15,6 +15,7 @@
 //! # Transactions Blinding
 //!
 
+use core::convert::TryFrom;
 use std::{self, collections::BTreeMap, fmt};
 
 use secp256k1_zkp::{
@@ -26,7 +27,6 @@ use secp256k1_zkp::{Generator, RangeProof, Secp256k1, Signing, SurjectionProof};
 
 use crate::{AddressParams, Script, TxIn};
 
-use crate::hashes;
 use crate::{
     confidential::{Asset, AssetBlindingFactor, Nonce, Value, ValueBlindingFactor},
     Address, AssetId, Transaction, TxOut, TxOutWitness,
@@ -762,7 +762,8 @@ impl TxOut {
         )?;
 
         let (asset, asset_bf) = opening.message.as_ref().split_at(32);
-        let asset = AssetId::from_slice(asset)?;
+        let asset = <[u8; 32]>::try_from(asset).map_err(UnblindError::MalformedAssetId)?;
+        let asset = AssetId::from_byte_array(asset);
         let asset_bf = AssetBlindingFactor::from_slice(&asset_bf[..32])?;
 
         let value = opening.value;
@@ -787,7 +788,7 @@ pub enum UnblindError {
     /// Transaction output does not have a rangeproof.
     MissingRangeproof,
     /// Malformed asset ID.
-    MalformedAssetId(hashes::FromSliceError),
+    MalformedAssetId(core::array::TryFromSliceError),
     /// Error originated in `secp256k1_zkp`.
     Upstream(secp256k1_zkp::Error),
 }
@@ -819,12 +820,6 @@ impl std::error::Error for UnblindError {
 impl From<secp256k1_zkp::Error> for UnblindError {
     fn from(from: secp256k1_zkp::Error) -> Self {
         UnblindError::Upstream(from)
-    }
-}
-
-impl From<hashes::FromSliceError> for UnblindError {
-    fn from(from: hashes::FromSliceError) -> Self {
-        UnblindError::MalformedAssetId(from)
     }
 }
 
@@ -1515,7 +1510,7 @@ mod tests {
 
     #[test]
     fn blind_value_proof_test() {
-        let id = AssetId::from_slice(&[1u8; 32]).unwrap();
+        let id = AssetId::from_byte_array([1u8; 32]);
         let abf = AssetBlindingFactor::new(&mut thread_rng());
         let asset = confidential::Asset::new_confidential(SECP256K1, id, abf);
 
@@ -1541,7 +1536,7 @@ mod tests {
 
     #[test]
     fn blind_asset_proof_test() {
-        let id = AssetId::from_slice(&[1u8; 32]).unwrap();
+        let id = AssetId::from_byte_array([1u8; 32]);
         let abf = AssetBlindingFactor::new(&mut thread_rng());
         let asset = confidential::Asset::new_confidential(SECP256K1, id, abf);
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -21,10 +21,15 @@ use std::io;
 #[cfg(feature = "serde")] use std::fmt;
 
 use crate::dynafed;
-use crate::hashes::{Hash, sha256};
+use crate::hashes::Hash;
 use crate::Transaction;
 use crate::encode::{self, serialize, Decodable, Encodable, VarInt};
 use crate::{BlockHash, Script, TxMerkleNode};
+
+impl_sha256_midstate_wrapper! {
+    /// The Merkle root of a set of dynafed parameters.
+    pub struct DynafedRoot([u8; 32]);
+}
 
 /// Data related to block signatures
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -268,7 +273,7 @@ impl BlockHeader {
     }
 
     /// Calculate the root of the dynafed params. Returns [None] when not dynafed.
-    pub fn calculate_dynafed_params_root(&self) -> Option<sha256::Midstate> {
+    pub fn calculate_dynafed_params_root(&self) -> Option<crate::DynafedRoot> {
         match self.ext {
             ExtData::Proof { .. } => None,
             ExtData::Dynafed { ref current, ref proposed, .. } => {
@@ -276,7 +281,7 @@ impl BlockHeader {
                     current.calculate_root().to_byte_array(),
                     proposed.calculate_root().to_byte_array(),
                 ];
-                Some(crate::fast_merkle_root::fast_merkle_root(&leaves[..]))
+                Some(DynafedRoot::from_midstate(crate::fast_merkle_root::fast_merkle_root(&leaves[..])))
             }
         }
     }

--- a/src/confidential.rs
+++ b/src/confidential.rs
@@ -1102,7 +1102,6 @@ impl<'de> Deserialize<'de> for ValueBlindingFactor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hashes::sha256;
 
     #[cfg(feature = "serde")]
     use std::str::FromStr;
@@ -1144,7 +1143,7 @@ mod tests {
 
         let assets = [
             Asset::Null,
-            Asset::Explicit(AssetId::from_inner(sha256::Midstate::from_byte_array([0; 32]))),
+            Asset::Explicit(AssetId::from_byte_array([0; 32])),
             Asset::from_commitment(&[
                 0x0a, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                 1, 1, 1, 1, 1, 1,

--- a/src/dynafed.rs
+++ b/src/dynafed.rs
@@ -23,8 +23,18 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::ser::{SerializeSeq, SerializeStruct};
 
 use crate::encode::{self, Encodable, Decodable};
-use crate::hashes::{Hash, sha256, sha256d};
+use crate::hashes::{Hash, sha256d};
 use crate::Script;
+
+impl_sha256_midstate_wrapper! {
+    /// The Merkle root of a set of dynafed parameters.
+    pub struct ParamsRoot([u8; 32]);
+}
+
+impl_sha256_midstate_wrapper! {
+    /// A hash of elided dynafed parameter data.
+    pub struct ElidedRoot([u8; 32]);
+}
 
 /// ad-hoc struct to fmt in hex
 #[cfg(feature = "serde")]
@@ -109,7 +119,7 @@ impl FullParams {
     /// Return the `extra root` of this params.
     /// The extra root commits to the consensus parameters unrelated to
     /// blocksigning: `fedpeg_program`, `fedpegscript` and `extension_space`.
-    fn extra_root(&self) -> sha256::Midstate {
+    fn extra_root(&self) -> ElidedRoot {
         fn serialize_hash<E: Encodable>(obj: &E) -> sha256d::Hash {
             let mut engine = sha256d::Hash::engine();
             obj.consensus_encode(&mut engine).expect("engines don't error");
@@ -121,11 +131,11 @@ impl FullParams {
             serialize_hash(&self.fedpegscript).to_byte_array(),
             serialize_hash(&self.extension_space).to_byte_array(),
         ];
-        crate::fast_merkle_root::fast_merkle_root(&leaves[..])
+        ElidedRoot::from_midstate(crate::fast_merkle_root::fast_merkle_root(&leaves[..]))
     }
 
     /// Calculate the root of this [`FullParams`].
-    pub fn calculate_root(&self) -> sha256::Midstate {
+    pub fn calculate_root(&self) -> ParamsRoot {
         fn serialize_hash<E: Encodable>(obj: &E) -> sha256d::Hash {
             let mut engine = sha256d::Hash::engine();
             obj.consensus_encode(&mut engine).expect("engines don't error");
@@ -142,7 +152,7 @@ impl FullParams {
             compact_root.to_byte_array(),
             self.extra_root().to_byte_array(),
         ];
-        crate::fast_merkle_root::fast_merkle_root(&leaves[..])
+        ParamsRoot::from_midstate(crate::fast_merkle_root::fast_merkle_root(&leaves[..]))
     }
 
     /// Turns parameters into compact parameters.
@@ -223,7 +233,7 @@ pub enum Params {
         /// Maximum, in bytes, of the size of a blocksigning witness
         signblock_witness_limit: u32,
         /// Merkle root of extra data
-        elided_root: sha256::Midstate,
+        elided_root: ElidedRoot,
     },
     /// Full dynamic federations parameters
     Full(FullParams),
@@ -319,7 +329,7 @@ impl Params {
     }
 
     /// Get the `elided_root`. Is [None] for non-[`Params::Compact`] params.
-    pub fn elided_root(&self) -> Option<&sha256::Midstate> {
+    pub fn elided_root(&self) -> Option<&ElidedRoot> {
         match *self {
             Params::Null => None,
             Params::Compact { ref elided_root, ..} => Some(elided_root),
@@ -330,16 +340,16 @@ impl Params {
     /// Return the `extra root` of this params.
     /// The extra root commits to the consensus parameters unrelated to
     /// blocksigning: `fedpeg_program`, `fedpegscript` and `extension_space`.
-    fn extra_root(&self) -> sha256::Midstate {
+    fn extra_root(&self) -> ElidedRoot {
         match *self {
-            Params::Null => sha256::Midstate::from_byte_array([0u8; 32]),
+            Params::Null => ElidedRoot::from_byte_array([0u8; 32]),
             Params::Compact { ref elided_root, .. } => *elided_root,
             Params::Full(ref f) => f.extra_root(),
         }
     }
 
     /// Calculate the root of this [Params].
-    pub fn calculate_root(&self) -> sha256::Midstate {
+    pub fn calculate_root(&self) -> ParamsRoot {
         fn serialize_hash<E: Encodable>(obj: &E) -> sha256d::Hash {
             let mut engine = sha256d::Hash::engine();
             obj.consensus_encode(&mut engine).expect("engines don't error");
@@ -347,7 +357,7 @@ impl Params {
         }
 
         if self.is_null() {
-            return sha256::Midstate::from_byte_array([0u8; 32]);
+            return ParamsRoot::from_byte_array([0u8; 32]);
         }
 
         let leaves = [
@@ -360,7 +370,7 @@ impl Params {
             compact_root.to_byte_array(),
             self.extra_root().to_byte_array(),
         ];
-        crate::fast_merkle_root::fast_merkle_root(&leaves[..])
+        ParamsRoot::from_midstate(crate::fast_merkle_root::fast_merkle_root(&leaves[..]))
     }
 
     /// Get the full params when this params are full.
@@ -626,7 +636,7 @@ impl Decodable for Params {
             1 => Ok(Params::Compact {
                 signblockscript: Decodable::consensus_decode(&mut d)?,
                 signblock_witness_limit: Decodable::consensus_decode(&mut d)?,
-                elided_root: sha256::Midstate::from_byte_array(Decodable::consensus_decode(&mut d)?),
+                elided_root: ElidedRoot::from_byte_array(Decodable::consensus_decode(&mut d)?),
             }),
             2 => Ok(Params::Full(Decodable::consensus_decode(&mut d)?)),
             _ => Err(encode::Error::ParseFailed(
@@ -640,7 +650,6 @@ impl Decodable for Params {
 mod tests {
     use std::fmt::{self, Write};
 
-    use crate::hashes::sha256;
     use crate::{BlockHash, TxMerkleNode};
 
     use super::*;
@@ -683,7 +692,7 @@ mod tests {
         let compact_entry = Params::Compact {
             signblockscript: signblockscript.clone(),
             signblock_witness_limit: signblock_wl,
-            elided_root: sha256::Midstate::from_byte_array([0; 32]),
+            elided_root: ElidedRoot::from_byte_array([0; 32]),
         };
         assert_eq!(
             format!("{:x}", compact_entry.calculate_root()),
@@ -751,7 +760,7 @@ mod tests {
         let compact = params.into_compact().unwrap();
         assert_eq!(
             to_debug_string(&compact),
-            "Compact { signblockscript: 0102, signblock_witness_limit: 3, elided_root: 0xc3058c822b22a13bb7c47cf50d3f3c7817e7d9075ff55a7d16c85b9673e7e553 }",
+            "Compact { signblockscript: 0102, signblock_witness_limit: 3, elided_root: c3058c822b22a13bb7c47cf50d3f3c7817e7d9075ff55a7d16c85b9673e7e553 }",
         );
         assert_eq!(compact.calculate_root(), full.calculate_root());
         assert_eq!(compact.elided_root(), Some(&extra_root));

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -202,18 +202,6 @@ pub fn deserialize_partial<T: Decodable>(data: &[u8]) -> Result<(T, usize), Erro
     Ok((rv, consumed))
 }
 
-impl Encodable for sha256::Midstate {
-    fn consensus_encode<W: io::Write>(&self, e: W) -> Result<usize, Error> {
-        self.to_byte_array().consensus_encode(e)
-    }
-}
-
-impl Decodable for sha256::Midstate {
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, Error> {
-        Ok(Self::from_byte_array(<[u8; 32]>::consensus_decode(d)?))
-    }
-}
-
 pub(crate) fn consensus_encode_with_size<S: crate::WriteExt>(
     data: &[u8],
     mut s: S,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -427,6 +427,7 @@ macro_rules! impl_array {
     };
 }
 impl_array!(4);
+impl_array!(20);
 impl_array!(32);
 impl_array!(33);
 

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -70,6 +70,20 @@ impl_hashencode!(Sighash);
 impl_hashencode!(BlockHash);
 impl_hashencode!(TxMerkleNode);
 
+impl ScriptHash {
+    /// Computes the `ScriptHash` of a script.
+    pub fn hash_script(s: &crate::Script) -> Self {
+        Self(hash160::Hash::hash(s.as_bytes()))
+    }
+}
+
+impl WScriptHash {
+    /// Computes the `WScriptHash` of a script.
+    pub fn hash_script(s: &crate::Script) -> Self {
+        Self(sha256::Hash::hash(s.as_bytes()))
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "serde")]
 mod serde_tests {

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -20,6 +20,9 @@
 
 use crate::hashes::{hash160, hash_newtype, sha256, sha256d, Hash};
 
+// Re-export bitcoin's pubkeyhash types. We already re-export bitcoin's `PublicKey` type.
+pub use bitcoin::{PubkeyHash, WPubkeyHash};
+
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {
         impl $crate::encode::Encodable for $hashtype {
@@ -52,12 +55,8 @@ hash_newtype! {
     /// "Hash of the transaction according to the signature algorithm"
     pub struct Sighash(sha256d::Hash);
 
-    /// A hash of a public key.
-    pub struct PubkeyHash(hash160::Hash);
     /// A hash of Bitcoin Script bytecode.
     pub struct ScriptHash(hash160::Hash);
-    /// SegWit version of a public key hash.
-    pub struct WPubkeyHash(hash160::Hash);
     /// SegWit version of a Bitcoin Script bytecode hash.
     pub struct WScriptHash(sha256::Hash);
 

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -70,3 +70,106 @@ impl_hashencode!(Wtxid);
 impl_hashencode!(Sighash);
 impl_hashencode!(BlockHash);
 impl_hashencode!(TxMerkleNode);
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod serde_tests {
+    use super::*;
+    use crate::{AssetId, ContractHash};
+
+    // Some types are currently just bare midstates. We will replace them with
+    // newtypes in the following commits. To ensure this does not break serde,
+    // test them here.
+    type AssetEntropy = sha256::Midstate;
+    type ElidedRoot = sha256::Midstate;
+    
+    /// An arbitrary test vector.
+    ///
+    /// Mainly its goal is to make sure we don't mess up and reverse stuff we don't
+    /// intend to reverse, or vice-versa, so its only requirement is that it not be
+    /// invariant under reversal.
+    const TEST_VECTOR: [u8; 32] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+        0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44,
+        0xff, 0xff, 0xff, 0xff, 0x11, 0x22, 0x33, 0x44,
+    ];
+
+    /// The vector encoded as CBOR
+    const CBOR: [u8; 34] = [
+        0x58, 0x20,
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+        0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44,
+        0xff, 0xff, 0xff, 0xff, 0x11, 0x22, 0x33, 0x44,
+    ];
+    /// The vector encoded as JSON (non-reversed hash)
+    const FORWARD_JSON: &str = "\"0102030405060708090a0b0c0d0e0f100000000011223344ffffffff11223344\"";
+    /// The vector encoded as JSON (reversed hash)
+    const REVERSED_JSON: &str = "\"44332211ffffffff4433221100000000100f0e0d0c0b0a090807060504030201\"";
+
+    /// Constructs a test which attempts to (de-)serialize the 32-byte hash `TEST_VECTOR`,
+    ///
+    /// Checks that serialization works, matches the given target, and can deserialize
+    /// to match the original value.
+    macro_rules! serde_rtt_test32 {
+        ($testname:ident, $ty:ty, $json:expr) => {
+            #[test]
+            fn $testname() {
+                let obj = <$ty>::from_byte_array(TEST_VECTOR);
+                // JSON (human-readable) round-trip
+                let enc_json = serde_json::to_string(&obj).expect("encode json");
+                assert_eq!(
+                    enc_json,
+                    $json,
+                    "encoded JSON did not match target '{}'", $json
+                );
+                let dec_json: $ty = serde_json::from_str(&enc_json).expect("decode json");
+                assert_eq!(
+                    dec_json,
+                    obj,
+                    "decoded JSON did not match object '{}'", obj
+                );
+
+                // CBOR (non-human-readable) round-trip
+                let enc_cbor = serde_cbor::to_vec(&obj).expect("encode cbor");
+                assert_eq!(
+                    enc_cbor,
+                    CBOR,
+                    "encoded CBOR did not match target '{:?}'", CBOR
+                );
+                let dec_cbor: $ty = serde_cbor::from_slice(&enc_cbor).expect("decode cbor");
+                assert_eq!(
+                    dec_cbor,
+                    obj,
+                    "decoded CBOR did not match object '{}'", obj
+                );
+
+                // While we're here, do a string round-trip test
+                let s = obj.to_string();
+                assert_eq!(
+                    s,
+                    $json[1..65],
+                    "encoded string did not match target '{:?}'", $json
+                );
+                let dec_s: $ty = s.parse().expect("parsing string");
+                assert_eq!(
+                    dec_s,
+                    obj,
+                    "decoded string did not match object '{}'", obj
+                );
+            }
+        }
+    }
+
+    serde_rtt_test32!(serde_rtt_txid, Txid, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_wtxid, Wtxid, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_blockhash, BlockHash, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_wscripthash, WScriptHash, FORWARD_JSON);
+    serde_rtt_test32!(serde_rtt_merklenode, TxMerkleNode, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_assetid, AssetId, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_contracthash, ContractHash, REVERSED_JSON);
+
+    serde_rtt_test32!(serde_rtt_entropy, AssetEntropy, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_elidedroot, ElidedRoot, REVERSED_JSON);
+}

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -75,12 +75,11 @@ impl_hashencode!(TxMerkleNode);
 #[cfg(feature = "serde")]
 mod serde_tests {
     use super::*;
-    use crate::{AssetId, ContractHash};
+    use crate::{AssetEntropy, AssetId, ContractHash};
 
     // Some types are currently just bare midstates. We will replace them with
     // newtypes in the following commits. To ensure this does not break serde,
     // test them here.
-    type AssetEntropy = sha256::Midstate;
     type ElidedRoot = sha256::Midstate;
     
     /// An arbitrary test vector.

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -75,13 +75,9 @@ impl_hashencode!(TxMerkleNode);
 #[cfg(feature = "serde")]
 mod serde_tests {
     use super::*;
-    use crate::{AssetEntropy, AssetId, ContractHash};
+    use crate::{AssetEntropy, AssetId, ContractHash, DynafedRoot};
+    use crate::dynafed::{ElidedRoot, ParamsRoot};
 
-    // Some types are currently just bare midstates. We will replace them with
-    // newtypes in the following commits. To ensure this does not break serde,
-    // test them here.
-    type ElidedRoot = sha256::Midstate;
-    
     /// An arbitrary test vector.
     ///
     /// Mainly its goal is to make sure we don't mess up and reverse stuff we don't
@@ -170,5 +166,7 @@ mod serde_tests {
     serde_rtt_test32!(serde_rtt_contracthash, ContractHash, REVERSED_JSON);
 
     serde_rtt_test32!(serde_rtt_entropy, AssetEntropy, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_dynaroot, DynafedRoot, REVERSED_JSON);
     serde_rtt_test32!(serde_rtt_elidedroot, ElidedRoot, REVERSED_JSON);
+    serde_rtt_test32!(serde_rtt_paramsroot, ParamsRoot, REVERSED_JSON);
 }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -395,6 +395,94 @@ macro_rules! serde_struct_human_string_impl {
     )
 }
 
+macro_rules! impl_sha256_midstate_wrapper {
+    {
+        #[$($type_attrs:meta)*]
+        pub struct $ty:ident([u8; 32]);
+    } => {
+        $(#[$type_attrs])*
+        #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+        pub struct $ty([u8; 32]);
+
+        impl $ty {
+            /// Constructs this wrapper struct from raw bytes.
+            pub fn from_byte_array(inner: [u8; 32]) -> Self {
+                Self(inner)
+            }
+
+            /// The raw bytes within the wrapper type.
+            pub fn as_byte_array(&self) -> &[u8; 32] {
+                &self.0
+            }
+
+            /// The raw bytes within the wrapper type.
+            pub fn to_byte_array(self) -> [u8; 32] {
+                self.0
+            }
+
+            /// (Private) convert a sha256 midstate to an object.
+            fn from_midstate(value: crate::hashes::sha256::Midstate) -> Self {
+                Self(value.to_byte_array())
+            }
+        }
+
+        impl ::std::fmt::Display for $ty {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                ::std::fmt::LowerHex::fmt(&self, f)
+            }
+        }
+
+        impl ::std::fmt::LowerHex for $ty {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                hex::fmt_hex_exact!(f, 32, self.0.iter().rev(), hex::Case::Lower)
+            }
+        }
+
+        impl ::std::fmt::UpperHex for $ty {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                hex::fmt_hex_exact!(f, 32, self.0.iter().rev(), hex::Case::Upper)
+            }
+        }
+
+        impl ::std::fmt::Debug for $ty {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                ::std::fmt::Display::fmt(&self, f)
+            }
+        }
+
+        impl ::core::str::FromStr for $ty {
+            type Err = hex::DecodeFixedLengthBytesError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let mut arr = hex::decode_to_array(s)?;
+                arr.reverse();
+                Ok(Self(arr))
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl ::serde::Serialize for $ty {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer {
+                // "cheat" by just copying sha256d serde serialization
+                crate::hashes::sha256d::Hash::from_byte_array(self.to_byte_array()).serialize(serializer)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de> ::serde::Deserialize<'de> for $ty {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de> {
+                // "cheat" by just copying sha256d serde serialization
+                let hash = crate::hashes::sha256d::Hash::deserialize(deserializer)?;
+                Ok(Self::from_byte_array(hash.to_byte_array()))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 macro_rules! hex_deserialize(
     ($e:expr) => ({

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -43,73 +43,9 @@ hash_newtype!(
 );
 
 
-/// A hash of some data used as "asset entropy" to seed the ID of a new asset.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct AssetEntropy([u8; 32]);
-
-impl AssetEntropy {
-    /// Constructs an asset entropy from a raw byte array.
-    pub fn from_byte_array(inner: [u8; 32]) -> Self {
-        Self(inner)
-    }
-
-    /// The raw bytes of the asset entropy.
-    pub fn as_byte_array(&self) -> &[u8; 32] {
-        &self.0
-    }
-
-    /// The raw bytes of the asset entropy.
-    pub fn to_byte_array(self) -> [u8; 32] {
-        self.0
-    }
-
-    /// Convert a sha256 midstate to a [`AssetEntropy`].
-    fn from_midstate(value: sha256::Midstate) -> Self {
-        Self(value.to_byte_array())
-    }
-}
-
-impl ::std::fmt::Display for AssetEntropy {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        hex::fmt_hex_exact!(f, 32, self.0.iter().rev(), hex::Case::Lower)
-    }
-}
-
-impl ::std::fmt::Debug for AssetEntropy {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self, f)
-    }
-}
-
-impl FromStr for AssetEntropy {
-    type Err = hex::DecodeFixedLengthBytesError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut arr = hex::decode_to_array(s)?;
-        arr.reverse();
-        Ok(Self(arr))
-    }
-}
-
-#[cfg(feature = "serde")]
-impl ::serde::Serialize for AssetEntropy {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer {
-        // "cheat" by just copying sha256d serde serialization
-        sha256d::Hash::from_byte_array(self.to_byte_array()).serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> ::serde::Deserialize<'de> for AssetEntropy {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de> {
-        // "cheat" by just copying sha256d serde serialization
-        let hash = sha256d::Hash::deserialize(deserializer)?;
-        Ok(Self::from_byte_array(hash.to_byte_array()))
-    }
+impl_sha256_midstate_wrapper! {
+    /// A hash of some data used as "asset entropy" to seed the ID of a new asset.
+    pub struct AssetEntropy([u8; 32]);
 }
 
 impl ContractHash {

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -15,10 +15,9 @@
 //! Asset Issuance
 
 use std::io;
-use std::str::FromStr;
 
 use crate::encode::{self, Encodable, Decodable};
-use crate::hashes::{self, hash_newtype, sha256, sha256d, Hash};
+use crate::hashes::{hash_newtype, sha256, sha256d, Hash};
 use crate::fast_merkle_root::fast_merkle_root;
 use secp256k1_zkp::Tag;
 use crate::transaction::OutPoint;
@@ -48,6 +47,11 @@ impl_sha256_midstate_wrapper! {
     pub struct AssetEntropy([u8; 32]);
 }
 
+impl_sha256_midstate_wrapper! {
+    /// An issued asset ID.
+    pub struct AssetId([u8; 32]);
+}
+
 impl ContractHash {
     /// Calculate the contract hash of a JSON contract object.
     ///
@@ -68,38 +72,14 @@ impl ContractHash {
     }
 }
 
-/// An issued asset ID.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct AssetId(sha256::Midstate);
-
 impl AssetId {
     /// The asset ID for L-BTC, Bitcoin on the Liquid network.
-    pub const LIQUID_BTC: AssetId = AssetId(sha256::Midstate([
+    pub const LIQUID_BTC: AssetId = AssetId([
         0x6d, 0x52, 0x1c, 0x38, 0xec, 0x1e, 0xa1, 0x57,
         0x34, 0xae, 0x22, 0xb7, 0xc4, 0x60, 0x64, 0x41,
         0x28, 0x29, 0xc0, 0xd0, 0x57, 0x9f, 0x0a, 0x71,
         0x3d, 0x1c, 0x04, 0xed, 0xe9, 0x79, 0x02, 0x6f,
-    ]));
-
-    /// Create an [`AssetId`] from its inner type.
-    pub const fn from_inner(midstate: sha256::Midstate) -> AssetId {
-        AssetId(midstate)
-    }
-
-    /// Convert the [`AssetId`] into its inner type.
-    pub fn into_inner(self) -> sha256::Midstate {
-        self.0
-    }
-
-    /// Constructs an asset ID from a raw byte array.
-    pub fn from_byte_array(inner: [u8; 32]) -> Self {
-        Self(sha256::Midstate::from_byte_array(inner))
-    }
-
-    /// Copies a byte slice into an `AssetId` object
-    pub fn from_slice(sl: &[u8]) -> Result<AssetId, hashes::FromSliceError> {
-        sha256::Midstate::from_slice(sl).map(AssetId)
-    }
+    ]);
 
     /// Generate the asset entropy from the issuance prevout and the contract hash.
     pub fn generate_asset_entropy(
@@ -123,7 +103,7 @@ impl AssetId {
         // H_a : asset tag
         // E   : entropy
         // H_a = H( E || 0 )
-        AssetId(fast_merkle_root(&[entropy.to_byte_array(), ZERO32]))
+        AssetId::from_midstate(fast_merkle_root(&[entropy.to_byte_array(), ZERO32]))
     }
 
     /// Computes the asset ID when issuing asset from issuing input and contract hash
@@ -150,37 +130,12 @@ impl AssetId {
             false => ONE32,
             true => TWO32,
         };
-        AssetId(fast_merkle_root(&[entropy.to_byte_array(), second]))
+        AssetId::from_midstate(fast_merkle_root(&[entropy.to_byte_array(), second]))
     }
 
     /// Convert an asset into [Tag]
     pub fn into_tag(self) -> Tag {
-        self.0.to_byte_array().into()
-    }
-}
-
-impl ::std::fmt::Display for AssetId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl ::std::fmt::Debug for AssetId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self, f)
-    }
-}
-
-impl ::std::fmt::LowerHex for AssetId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::std::fmt::LowerHex::fmt(&self.0, f)
-    }
-}
-
-impl FromStr for AssetId {
-    type Err = crate::hashes::hex::HexToArrayError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        sha256::Midstate::from_str(s).map(AssetId)
+        self.0.into()
     }
 }
 
@@ -192,78 +147,7 @@ impl Encodable for AssetId {
 
 impl Decodable for AssetId {
     fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        Ok(Self::from_inner(sha256::Midstate::consensus_decode(d)?))
-    }
-}
-
-#[cfg(feature = "serde")]
-impl ::serde::Serialize for AssetId {
-    fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        if s.is_human_readable() {
-            s.collect_str(self)
-        } else {
-            s.serialize_bytes(&self.0[..])
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> ::serde::Deserialize<'de> for AssetId {
-    fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<AssetId, D::Error> {
-        if d.is_human_readable() {
-            struct HexVisitor;
-
-            impl ::serde::de::Visitor<'_> for HexVisitor {
-                type Value = AssetId;
-
-                fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    formatter.write_str("an ASCII hex string")
-                }
-
-                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                where
-                    E: ::serde::de::Error,
-                {
-                    if let Ok(hex) = ::std::str::from_utf8(v) {
-                        AssetId::from_str(hex).map_err(E::custom)
-                    } else {
-                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
-                    }
-                }
-
-                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                where
-                    E: ::serde::de::Error,
-                {
-                    AssetId::from_str(v).map_err(E::custom)
-                }
-            }
-
-            d.deserialize_str(HexVisitor)
-        } else {
-            struct BytesVisitor;
-
-            impl ::serde::de::Visitor<'_> for BytesVisitor {
-                type Value = AssetId;
-
-                fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    formatter.write_str("a bytestring")
-                }
-
-                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                where
-                    E: ::serde::de::Error,
-                {
-                    use core::convert::TryFrom;
-                    match <[u8; 32]>::try_from(v) {
-                        Ok(ret) => Ok(AssetId(sha256::Midstate::from_byte_array(ret))),
-                        Err(_) => Err(E::invalid_length(v.len(), &stringify!($len))),
-                    }
-                }
-            }
-
-            d.deserialize_bytes(BytesVisitor)
-        }
+        Decodable::consensus_decode(d).map(Self)
     }
 }
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -37,10 +37,80 @@ const TWO32: [u8; 32] = [
 ];
 
 hash_newtype!(
-    /// The hash of an asset contract.", tru)
+    /// The hash of an asset contract.
     #[hash_newtype(backward)]
     pub struct ContractHash(sha256::Hash);
 );
+
+
+/// A hash of some data used as "asset entropy" to seed the ID of a new asset.
+#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+pub struct AssetEntropy([u8; 32]);
+
+impl AssetEntropy {
+    /// Constructs an asset entropy from a raw byte array.
+    pub fn from_byte_array(inner: [u8; 32]) -> Self {
+        Self(inner)
+    }
+
+    /// The raw bytes of the asset entropy.
+    pub fn as_byte_array(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// The raw bytes of the asset entropy.
+    pub fn to_byte_array(self) -> [u8; 32] {
+        self.0
+    }
+
+    /// Convert a sha256 midstate to a [`AssetEntropy`].
+    fn from_midstate(value: sha256::Midstate) -> Self {
+        Self(value.to_byte_array())
+    }
+}
+
+impl ::std::fmt::Display for AssetEntropy {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        hex::fmt_hex_exact!(f, 32, self.0.iter().rev(), hex::Case::Lower)
+    }
+}
+
+impl ::std::fmt::Debug for AssetEntropy {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::std::fmt::Display::fmt(&self, f)
+    }
+}
+
+impl FromStr for AssetEntropy {
+    type Err = hex::DecodeFixedLengthBytesError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut arr = hex::decode_to_array(s)?;
+        arr.reverse();
+        Ok(Self(arr))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl ::serde::Serialize for AssetEntropy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer {
+        // "cheat" by just copying sha256d serde serialization
+        sha256d::Hash::from_byte_array(self.to_byte_array()).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> ::serde::Deserialize<'de> for AssetEntropy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de> {
+        // "cheat" by just copying sha256d serde serialization
+        let hash = sha256d::Hash::deserialize(deserializer)?;
+        Ok(Self::from_byte_array(hash.to_byte_array()))
+    }
+}
 
 impl ContractHash {
     /// Calculate the contract hash of a JSON contract object.
@@ -99,7 +169,7 @@ impl AssetId {
     pub fn generate_asset_entropy(
         prevout: OutPoint,
         contract_hash: ContractHash,
-    ) -> sha256::Midstate {
+    ) -> AssetEntropy {
         // E : entropy
         // I : prevout
         // C : contract
@@ -109,11 +179,11 @@ impl AssetId {
             prevout.consensus_encode(&mut enc).unwrap();
             sha256d::Hash::from_engine(enc)
         };
-        fast_merkle_root(&[prevout_hash.to_byte_array(), contract_hash.to_byte_array()])
+        AssetEntropy::from_midstate(fast_merkle_root(&[prevout_hash.to_byte_array(), contract_hash.to_byte_array()]))
     }
 
     /// Calculate the asset ID from the asset entropy.
-    pub fn from_entropy(entropy: sha256::Midstate) -> AssetId {
+    pub fn from_entropy(entropy: AssetEntropy) -> AssetId {
         // H_a : asset tag
         // E   : entropy
         // H_a = H( E || 0 )
@@ -133,7 +203,7 @@ impl AssetId {
     }
 
     /// Calculate the reissuance token asset ID from the asset entropy.
-    pub fn reissuance_token_from_entropy(entropy: sha256::Midstate, confidential: bool) -> AssetId {
+    pub fn reissuance_token_from_entropy(entropy: AssetEntropy, confidential: bool) -> AssetId {
         // H_a : asset reissuance tag
         // E   : entropy
         // if not fConfidential:
@@ -266,8 +336,6 @@ mod test {
     use super::*;
     use std::str::FromStr;
 
-    use crate::hashes::sha256;
-
     #[test]
     fn example_elements_core() {
         // example test data from Elements Core 0.17
@@ -278,7 +346,7 @@ mod test {
 
         let contract_hash = ContractHash::from_byte_array(ZERO32);
         let prevout = OutPoint::from_str(prevout_str).unwrap();
-        let entropy = sha256::Midstate::from_str(entropy_hex).unwrap();
+        let entropy = AssetEntropy::from_str(entropy_hex).unwrap();
         assert_eq!(AssetId::generate_asset_entropy(prevout, contract_hash), entropy);
         let asset_id = AssetId::from_str(asset_id_hex).unwrap();
         assert_eq!(AssetId::from_entropy(entropy), asset_id);
@@ -293,7 +361,7 @@ mod test {
 
         let contract_hash = ContractHash::from_byte_array(ZERO32);
         let prevout = OutPoint::from_str(prevout_str).unwrap();
-        let entropy = sha256::Midstate::from_str(entropy_hex).unwrap();
+        let entropy = AssetEntropy::from_str(entropy_hex).unwrap();
         assert_eq!(AssetId::generate_asset_entropy(prevout, contract_hash), entropy);
         let asset_id = AssetId::from_str(asset_id_hex).unwrap();
         assert_eq!(AssetId::from_entropy(entropy), asset_id);
@@ -310,7 +378,7 @@ mod test {
 
         let contract_hash = ContractHash::from_str(contract_hash_hex).unwrap();
         let prevout = OutPoint::from_str(prevout_str).unwrap();
-        let entropy = sha256::Midstate::from_str(entropy_hex).unwrap();
+        let entropy = AssetEntropy::from_str(entropy_hex).unwrap();
         assert_eq!(AssetId::generate_asset_entropy(prevout, contract_hash), entropy);
         let asset_id = AssetId::from_str(asset_id_hex).unwrap();
         assert_eq!(AssetId::from_entropy(entropy), asset_id);
@@ -326,7 +394,7 @@ mod test {
 
         let contract_hash = ContractHash::from_byte_array(ZERO32);
         let prevout = OutPoint::from_str(prevout_str).unwrap();
-        let entropy = sha256::Midstate::from_str(entropy_hex).unwrap();
+        let entropy = AssetEntropy::from_str(entropy_hex).unwrap();
         assert_eq!(AssetId::generate_asset_entropy(prevout, contract_hash), entropy);
         let asset_id = AssetId::from_str(asset_id_hex).unwrap();
         assert_eq!(AssetId::from_entropy(entropy), asset_id);

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -85,6 +85,11 @@ impl AssetId {
         self.0
     }
 
+    /// Constructs an asset ID from a raw byte array.
+    pub fn from_byte_array(inner: [u8; 32]) -> Self {
+        Self(sha256::Midstate::from_byte_array(inner))
+    }
+
     /// Copies a byte slice into an `AssetId` object
     pub fn from_slice(sl: &[u8]) -> Result<AssetId, hashes::FromSliceError> {
         sha256::Midstate::from_slice(sl).map(AssetId)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::blind::{
     SurjectionInput, TxOutError, TxOutSecrets, UnblindError, VerificationError, CtLocation, CtLocationType,
 };
 pub use crate::block::ExtData as BlockExtData;
-pub use crate::block::{Block, BlockHeader};
+pub use crate::block::{Block, BlockHeader, DynafedRoot};
 pub use crate::ext::{ReadExt, WriteExt};
 pub use crate::fast_merkle_root::fast_merkle_root;
 pub use crate::hash_types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@ pub extern crate hex;
 pub extern crate secp256k1_zkp;
 /// Re-export of serde crate
 #[cfg(feature = "serde")]
-#[macro_use]
-pub extern crate actual_serde as serde;
+pub extern crate serde;
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub use crate::block::{Block, BlockHeader};
 pub use crate::ext::{ReadExt, WriteExt};
 pub use crate::fast_merkle_root::fast_merkle_root;
 pub use crate::hash_types::*;
-pub use crate::issuance::{AssetId, ContractHash};
+pub use crate::issuance::{AssetEntropy, AssetId, ContractHash};
 pub use crate::locktime::LockTime;
 pub use crate::schnorr::{SchnorrSig, SchnorrSigError};
 pub use crate::script::Script;

--- a/src/locktime.rs
+++ b/src/locktime.rs
@@ -66,8 +66,7 @@ pub const LOCK_TIME_THRESHOLD: u32 = 500_000_000;
 /// ```
 #[allow(clippy::derive_ord_xor_partial_ord)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LockTime {
     /// A block height lock time value.
     ///
@@ -293,8 +292,7 @@ impl Decodable for LockTime {
 
 /// An absolute block height, guaranteed to always contain a valid height value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Height(u32);
 
 impl Height {
@@ -379,8 +377,7 @@ impl TryFrom<String> for Height {
 /// `to_consensus_u32()`. Said another way, `Time(x)` means 'x seconds since epoch' _not_ '(x -
 /// threshold) seconds since epoch'.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Time(u32);
 
 impl Time {

--- a/src/pset/elip102.rs
+++ b/src/pset/elip102.rs
@@ -124,7 +124,7 @@ mod test {
         pset.add_input(input);
         let mut output = Output {
             amount: Some(1),
-            asset: Some(AssetId::from_slice(&[9; 32]).unwrap()),
+            asset: Some(AssetId::from_byte_array([9; 32])),
             ..Default::default()
         };
         output.set_abf(abf);

--- a/src/pset/error.rs
+++ b/src/pset/error.rs
@@ -20,7 +20,6 @@ use crate::Txid;
 use super::raw;
 
 use crate::blind::ConfidentialTxOutError;
-use crate::hashes;
 use secp256k1_zkp;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -70,8 +69,6 @@ pub enum Error {
     },
     /// Unable to parse as a standard Sighash type.
     NonStandardSighashType(u32),
-    /// Parsing errors from `bitcoin_hashes`
-    HashParseError(hashes::FromSliceError),
     /// The pre-image must hash to the corresponding pset hash
     InvalidPreimageHashPair {
         /// Hash-type
@@ -148,7 +145,6 @@ impl fmt::Display for Error {
                 f.write_str("partially signed transactions must have an unsigned transaction")
             }
             Error::NoMorePairs => f.write_str("no more key-value pairs for this pset map"),
-            Error::HashParseError(e) => write!(f, "Hash Parse Error: {}", e),
             Error::InvalidPreimageHashPair {
                 ref preimage,
                 ref hash,
@@ -216,13 +212,6 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {}
-
-#[doc(hidden)]
-impl From<hashes::FromSliceError> for Error {
-    fn from(e: hashes::FromSliceError) -> Error {
-        Error::HashParseError(e)
-    }
-}
 
 impl From<encode::Error> for Error {
     fn from(err: encode::Error) -> Self {

--- a/src/pset/error.rs
+++ b/src/pset/error.rs
@@ -51,12 +51,6 @@ pub enum Error {
     /// PSET has an input exclusively requiring a height-based locktime and also
     /// an input requiring a time-based locktime
     LocktimeConflict,
-    /// The scriptSigs for the unsigned transaction must be empty.
-    UnsignedTxHasScriptSigs,
-    /// The scriptWitnesses for the unsigned transaction must be empty.
-    UnsignedTxHasScriptWitnesses,
-    /// A PSET must have an unsigned transaction.
-    MustHaveUnsignedTx,
     /// Signals that there are no more key-value pairs in a key-value map.
     NoMorePairs,
     /// Attempting to merge with a PSET describing a different unsigned
@@ -67,8 +61,6 @@ pub enum Error {
         /// Actual
         actual: Txid,
     },
-    /// Unable to parse as a standard Sighash type.
-    NonStandardSighashType(u32),
     /// The pre-image must hash to the corresponding pset hash
     InvalidPreimageHashPair {
         /// Hash-type
@@ -98,8 +90,6 @@ pub enum Error {
     MissingInputPrevTxId,
     /// Missing Input Prev Out
     MissingInputPrevVout,
-    /// Global scalar must be 32 bytes
-    SecpScalarSizeError(usize),
     /// Missing Output Value
     MissingOutputValue,
     /// Missing Output Asset
@@ -130,20 +120,8 @@ impl fmt::Display for Error {
                 expected: ref e,
                 actual: ref a,
             } => write!(f, "different id: expected {}, actual {}", e, a),
-            Error::NonStandardSighashType(ref sht) => {
-                write!(f, "non-standard sighash type: {}", sht)
-            }
             Error::InvalidMagic => f.write_str("invalid magic"),
             Error::InvalidSeparator => f.write_str("invalid separator"),
-            Error::UnsignedTxHasScriptSigs => {
-                f.write_str("the unsigned transaction has script sigs")
-            }
-            Error::UnsignedTxHasScriptWitnesses => {
-                f.write_str("the unsigned transaction has script witnesses")
-            }
-            Error::MustHaveUnsignedTx => {
-                f.write_str("partially signed transactions must have an unsigned transaction")
-            }
             Error::NoMorePairs => f.write_str("no more key-value pairs for this pset map"),
             Error::InvalidPreimageHashPair {
                 ref preimage,
@@ -173,13 +151,6 @@ impl fmt::Display for Error {
             Error::MissingOutputCount => f.write_str("PSET missing output count"),
             Error::MissingInputPrevTxId => f.write_str("PSET input missing previous txid"),
             Error::MissingInputPrevVout => f.write_str("PSET input missing previous output index"),
-            Error::SecpScalarSizeError(actual) => {
-                write!(
-                    f,
-                    "PSET blinding scalars must be 32 bytes. Found {} bytes",
-                    actual
-                )
-            }
             Error::MissingOutputValue => f.write_str(
                 "PSET output missing value. Must have \
                 at least one of explicit/confidential value set",

--- a/src/pset/macros.rs
+++ b/src/pset/macros.rs
@@ -211,8 +211,7 @@ macro_rules! impl_pset_hash_deserialize {
     ($hash_type:ty) => {
         impl $crate::pset::serialize::Deserialize for $hash_type {
             fn deserialize(bytes: &[u8]) -> Result<Self, $crate::encode::Error> {
-                <$hash_type>::from_slice(&bytes[..])
-                    .map_err(|e| $crate::pset::Error::from(e).into())
+                $crate::encode::deserialize(bytes).map(Self::from_byte_array)
             }
         }
     };

--- a/src/pset/map/global.rs
+++ b/src/pset/map/global.rs
@@ -58,7 +58,7 @@ const PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE: u8 = 0x01;
 
 /// Global transaction data
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TxData {
     /// Transaction version. Must be 2.
     pub version: u32,
@@ -93,7 +93,7 @@ impl Default for TxData {
 
 /// A key-value map for global data.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Global {
     /// Global transaction data
     #[cfg_attr(feature = "serde", serde(flatten))]

--- a/src/pset/map/input.rs
+++ b/src/pset/map/input.rs
@@ -171,7 +171,7 @@ const PSBT_ELEMENTS_IN_BLINDED_ISSUANCE: u8 = 0x15;
 /// A key-value map for an input of the corresponding index in the unsigned
 /// transaction.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Input {
     /// The non-witness transaction this input spends from. Should only be
     /// [`std::option::Option::Some`] for inputs which spend non-segwit outputs or

--- a/src/pset/map/input.rs
+++ b/src/pset/map/input.rs
@@ -26,6 +26,7 @@ use crate::{schnorr, AssetId, ContractHash};
 use crate::{confidential, locktime};
 use crate::encode::{self, Decodable};
 use crate::hashes::{self, hash160, ripemd160, sha256, sha256d, Hash};
+use crate::issuance::AssetEntropy;
 use crate::pset::map::Map;
 use crate::pset::raw;
 use crate::pset::serialize;
@@ -560,7 +561,7 @@ impl Input {
             AssetId::generate_asset_entropy(prevout, contract_hash)
         } else {
             // re-issuance
-            sha256::Midstate::from_byte_array(self.issuance_asset_entropy.unwrap_or_default())
+            AssetEntropy::from_byte_array(self.issuance_asset_entropy.unwrap_or_default())
         };
         let asset_id = AssetId::from_entropy(entropy);
         let token_id =

--- a/src/pset/map/output.rs
+++ b/src/pset/map/output.rs
@@ -87,7 +87,7 @@ const PSBT_ELEMENTS_OUT_BLIND_ASSET_PROOF: u8 = 0x0a;
 /// A key-value map for an output of the corresponding index in the unsigned
 /// transaction.
 #[derive(Clone, Default, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Output {
     /// The redeem script for this output.
     pub redeem_script: Option<Script>,
@@ -146,7 +146,7 @@ pub struct Output {
 
 /// Taproot Tree representing a finalized [`TaprootBuilder`] (a complete binary tree)
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TapTree(pub(crate) TaprootBuilder);
 
 impl PartialEq for TapTree {

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -59,7 +59,7 @@ pub use self::map::{Global, GlobalTxData, Input, Output, PsbtSighashType, TapTre
 
 /// A Partially Signed Transaction.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PartiallySignedTransaction {
     /// The key-value pairs for all global data.
     pub global: Global,

--- a/src/pset/raw.rs
+++ b/src/pset/raw.rs
@@ -26,8 +26,7 @@ use hex::DisplayHex as _;
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
 #[cfg_attr(
     feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "actual_serde")
+    derive(serde::Serialize, serde::Deserialize),
 )]
 pub struct Key {
     /// The type of this PSET key.
@@ -53,8 +52,7 @@ impl Key {
 #[derive(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "actual_serde")
+    derive(serde::Serialize, serde::Deserialize),
 )]
 pub struct Pair {
     /// The key of this key-value pair.
@@ -71,8 +69,7 @@ pub type ProprietaryType = u8;
 /// structure according to BIP 174.
 #[cfg_attr(
     feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "actual_serde")
+    derive(serde::Serialize, serde::Deserialize),
 )]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct ProprietaryKey<Subtype = ProprietaryType>

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -205,7 +205,7 @@ impl From<TweakedKeypair> for TweakedPublicKey {
 
 /// A BIP340-341 serialized schnorr signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SchnorrSig {
     /// The underlying schnorr signature
     pub sig: secp256k1_zkp::schnorr::Signature,

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -146,8 +146,7 @@ pub mod btreemap_as_seq_byte_values {
     use serde;
 
     /// A custom key-value pair type that serialized the bytes as hex.
-    #[derive(Debug, Deserialize)]
-    #[serde(crate = "actual_serde")]
+    #[derive(Debug, serde::Deserialize)]
     struct OwnedPair<T>(
         T,
         #[serde(deserialize_with = "crate::serde_utils::hex_bytes::deserialize")]
@@ -155,8 +154,7 @@ pub mod btreemap_as_seq_byte_values {
     );
 
     /// A custom key-value pair type that serialized the bytes as hex.
-    #[derive(Debug, Serialize)]
-    #[serde(crate = "actual_serde")]
+    #[derive(Debug, serde::Serialize)]
     struct BorrowedPair<'a, T: 'static>(
         &'a T,
         #[serde(serialize_with = "crate::serde_utils::hex_bytes::serialize")]

--- a/src/sighash.rs
+++ b/src/sighash.rs
@@ -27,6 +27,7 @@ use crate::script::Script;
 use std::ops::{Deref, DerefMut};
 use std::io;
 use crate::endian;
+use crate::taproot::LeafVersion;
 use crate::transaction::{EcdsaSighashType, Transaction, TxIn, TxOut, TxInWitness};
 use crate::confidential;
 use crate::Sequence;
@@ -105,7 +106,7 @@ const KEY_VERSION_0: u8 = 0u8;
 pub struct ScriptPath<'s> {
     script: &'s Script,
     code_separator_pos: u32,
-    leaf_version: u8,
+    leaf_version: LeafVersion,
 }
 
 /// Possible errors in computing the signature message
@@ -203,7 +204,7 @@ impl<T> Prevouts<'_, T> where T: Borrow<TxOut> {
 
 impl<'s> ScriptPath<'s> {
     /// Create a new `ScriptPath` structure
-    pub fn new(script: &'s Script, code_separator_pos: u32, leaf_version: u8) -> Self {
+    pub fn new(script: &'s Script, code_separator_pos: u32, leaf_version: LeafVersion) -> Self {
         ScriptPath {
             script,
             code_separator_pos,
@@ -212,17 +213,12 @@ impl<'s> ScriptPath<'s> {
     }
     /// Create a new `ScriptPath` structure using default values for `code_separator_pos` and `leaf_version`
     pub fn with_defaults(script: &'s Script) -> Self {
-        Self::new(script, 0xFFFF_FFFFu32, 0xc4)
+        Self::new(script, 0xFFFF_FFFFu32, LeafVersion::TAPSCRIPT)
     }
 
     /// Compute the leaf hash
     pub fn leaf_hash(&self) -> TapLeafHash {
-        let mut enc = TapLeafHash::engine();
-
-        self.leaf_version.consensus_encode(&mut enc).expect("Writing to hash enging should never fail");
-        self.script.consensus_encode(&mut enc).expect("Writing to hash enging should never fail");
-
-        TapLeafHash::from_engine(enc)
+        TapLeafHash::from_script(self.script, self.leaf_version)
     }
 }
 

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -294,7 +294,7 @@ impl TaprootSpendInfo {
 /// branches in a DFS(Depth first search) walk to construct this tree.
 // Similar to Taproot Builder in bitcoin core
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TaprootBuilder {
     // The following doc-comment is from bitcoin core, but modified for rust
     // The comment below describes the current state of the builder for a given tree.
@@ -444,7 +444,7 @@ impl TaprootBuilder {
 
 /// Structure to represent the node information in taproot tree
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NodeInfo {
     /// Merkle Hash for this node
     pub(crate) hash: sha256::Hash,
@@ -498,7 +498,7 @@ impl NodeInfo {
 
 /// Data Structure to store information about taproot leaf node
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LeafInfo {
     // The underlying script
     pub(crate) script: Script,
@@ -529,8 +529,7 @@ impl LeafInfo {
 // The type of hash is sha256::Hash because the vector might contain
 // both TapNodeHash and TapLeafHash
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TaprootMerkleBranch(Vec<sha256::Hash>);
 
 impl TaprootMerkleBranch {
@@ -602,7 +601,7 @@ impl TaprootMerkleBranch {
 
 /// Control Block data structure used in Tapscript satisfaction
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ControlBlock {
     /// The tapleaf version,
     pub leaf_version: LeafVersion,
@@ -711,7 +710,7 @@ impl ControlBlock {
 
 /// The leaf version for tapleafs
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LeafVersion(u8);
 
 impl Default for LeafVersion {

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -16,7 +16,7 @@
 use std::cmp::Reverse;
 use std::{error, io, fmt};
 
-use crate::hashes::{sha256, sha256t_hash_newtype, Hash, HashEngine};
+use crate::hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use crate::schnorr::{UntweakedPublicKey, TweakedPublicKey, TapTweak};
 use crate::Script;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
@@ -373,7 +373,7 @@ impl TaprootBuilder {
     /// Add a hidden/omitted node at a depth `depth` to the builder.
     /// This will error if the node are not provided in a DFS walk order. The depth of the
     /// root node is 0 and it's immediate child would be at depth 1.
-    pub fn add_hidden(self, depth: usize, hash: sha256::Hash) -> Result<Self, TaprootBuilderError> {
+    pub fn add_hidden(self, depth: usize, hash: TapNodeHash) -> Result<Self, TaprootBuilderError> {
         let node = NodeInfo::new_hidden(hash);
         self.insert(node, depth)
     }
@@ -447,14 +447,14 @@ impl TaprootBuilder {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NodeInfo {
     /// Merkle Hash for this node
-    pub(crate) hash: sha256::Hash,
+    pub(crate) hash: TapNodeHash,
     /// information about leaves inside this node
     pub(crate) leaves: Vec<LeafInfo>,
 }
 
 impl NodeInfo {
     /// Creates a new `NodeInfo` with omitted/hidden info
-    pub fn new_hidden(hash: sha256::Hash) -> Self {
+    pub fn new_hidden(hash: TapNodeHash) -> Self {
         Self {
             hash,
             leaves: vec![],
@@ -490,7 +490,7 @@ impl NodeInfo {
             eng.input(a.hash.as_ref());
         };
         Ok(Self {
-            hash: sha256::Hash::from_engine(eng),
+            hash: TapNodeHash::from_engine(eng),
             leaves: all_leaves,
         })
     }
@@ -519,9 +519,9 @@ impl LeafInfo {
     }
 
     // Computes a leaf hash for the given leaf
-    fn hash(&self) -> sha256::Hash {
+    fn hash(&self) -> TapNodeHash {
         let leaf_hash = TapLeafHash::from_script(&self.script, self.ver);
-        sha256::Hash::from_byte_array(leaf_hash.to_byte_array())
+        TapNodeHash::from_byte_array(leaf_hash.to_byte_array())
     }
 }
 
@@ -530,11 +530,11 @@ impl LeafInfo {
 // both TapNodeHash and TapLeafHash
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct TaprootMerkleBranch(Vec<sha256::Hash>);
+pub struct TaprootMerkleBranch(Vec<TapNodeHash>);
 
 impl TaprootMerkleBranch {
     /// Obtain a reference to inner
-    pub fn as_inner(&self) -> &[sha256::Hash] {
+    pub fn as_inner(&self) -> &[TapNodeHash] {
         &self.0
     }
 
@@ -551,7 +551,7 @@ impl TaprootMerkleBranch {
                 // TODO: Use chunks_exact after MSRV changes to 1.31
                 .chunks(TAPROOT_CONTROL_NODE_SIZE)
                 .map(|chunk| {
-                    sha256::Hash::from_slice(chunk)
+                    TapNodeHash::from_slice(chunk)
                         .expect("chunk exact always returns the correct size")
                 })
                 .collect();
@@ -570,11 +570,11 @@ impl TaprootMerkleBranch {
 
     /// Serialize self as bytes
     pub fn serialize(&self) -> Vec<u8> {
-        self.0.iter().flat_map(sha256::Hash::as_byte_array).copied().collect::<Vec<u8>>()
+        self.0.iter().flat_map(TapNodeHash::as_byte_array).copied().collect::<Vec<u8>>()
     }
 
     // Internal function to append elements to proof
-    fn push(&mut self, h: sha256::Hash) -> Result<(), TaprootBuilderError> {
+    fn push(&mut self, h: TapNodeHash) -> Result<(), TaprootBuilderError> {
         if self.0.len() >= TAPROOT_CONTROL_MAX_NODE_COUNT {
             Err(TaprootBuilderError::InvalidMerkleTreeDepth(self.0.len()))
         } else {
@@ -583,9 +583,12 @@ impl TaprootMerkleBranch {
         }
     }
 
-    /// Create a `MerkleProof` from Vec<[`sha256::Hash`]>. Returns an error when
-    /// inner proof len is more than `TAPROOT_CONTROL_MAX_NODE_COUNT` (128)
-    pub fn from_inner(inner: Vec<sha256::Hash>) -> Result<Self, TaprootError> {
+    /// Create a `MerkleProof` from Vec<[`TapNodeHash`]>.
+    ///
+    /// # Errors
+    ///
+    /// Errors if inner proof len is more than `TAPROOT_CONTROL_MAX_NODE_COUNT` (128)
+    pub fn from_inner(inner: Vec<TapNodeHash>) -> Result<Self, TaprootError> {
         if inner.len() > TAPROOT_CONTROL_MAX_NODE_COUNT {
             Err(TaprootError::InvalidMerkleTreeDepth(inner.len()))
         } else {
@@ -593,8 +596,8 @@ impl TaprootMerkleBranch {
         }
     }
 
-    /// Consume Self to get Vec<[`sha256::Hash`]>
-    pub fn into_inner(self) -> Vec<sha256::Hash> {
+    /// Consume Self to get Vec<[`TapNodeHash`]>
+    pub fn into_inner(self) -> Vec<TapNodeHash> {
         self.0
     }
 }
@@ -851,7 +854,7 @@ impl error::Error for TaprootError {}
 #[cfg(test)]
 mod tests{
     use super::*;
-    use crate::hashes::HashEngine;
+    use crate::hashes::{sha256, HashEngine};
     use crate::hashes::sha256t::Tag;
     use std::str::FromStr;
 

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -723,6 +723,9 @@ impl Default for LeafVersion {
 }
 
 impl LeafVersion {
+    /// The leaf version used for Tapscript branches.
+    pub const TAPSCRIPT: Self = Self(TAPROOT_LEAF_TAPSCRIPT);
+
     /// Obtain `LeafVersion` from u8, will error when last bit of ver is even or
     /// when ver is 0x50 (`ANNEX_TAG`)
     // Text from BIP341:

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -171,8 +171,7 @@ impl ::std::str::FromStr for OutPoint {
 /// [BIP-68]: <https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki>
 /// [BIP-125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki>
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Sequence(pub u32);
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -20,11 +20,11 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use bitcoin::{self, VarInt};
-use crate::hashes::{Hash, sha256};
+use crate::hashes::Hash;
 
 use crate::{confidential, ContractHash};
 use crate::encode::{self, Encodable, Decodable};
-use crate::issuance::AssetId;
+use crate::issuance::{AssetEntropy, AssetId};
 use crate::opcodes;
 use crate::parse::impl_parse_str_through_int;
 use crate::script::Instruction;
@@ -626,7 +626,7 @@ impl TxIn {
             AssetId::generate_asset_entropy(self.previous_output, contract_hash)
         } else {
             // re-issuance
-            sha256::Midstate::from_byte_array(self.asset_issuance.asset_entropy)
+            AssetEntropy::from_byte_array(self.asset_issuance.asset_entropy)
         };
         let asset_id = AssetId::from_entropy(entropy);
         let token_id =


### PR DESCRIPTION
I am going to PR soon to update to bitcoin-hashes 1.0. There are several big changes versus the old version of bitcoin-hashes that we were using:

* Hash wrapper types (like `Txid`, `Blockhash`, etc) no longer have general hashing methods like `hash` that let you hash up arbitrary data; the intention of these types is that they only be constructable from byte slices or by hashing the right kind of data
* We no longer directly support construction from byte slices; instead you must use arrays. stdlib has a `TryFrom<&[u8; N]> for &[u8]` impl which is just a pointer cast, so you can get the old behavior by using this `TryFrom`
* The `sha256::Midstate` type now carries a length with it, so it behaves something like a deconstructed hash engine rather than being a "hash" which is computed from the sha256 compression function; you can no longer effectively wrap a midstate the way you would wrap a sha256 hash, so instead we directly wrap `[u8; 32]`s for the types that did this
* Many changes to make the macros more ergonomic, standard trait impls more consistent and complete, etc

This PR makes a bunch of prepatory changes to make this transition smaller. In particular, it

* eliminate all the bare `sha256::Midstate` uses by introducing newtypes for each midstate (asset entropy, dynafed elided params, etc)
* replace slices with arrays in many places throughout the codebase, eliminating a ton of unreachable panic paths
* **makes `Address::p2wpkh` and `Address::p2shwpkh` panic if you give them uncompressed keys** rather than producing unspendable addresses; later we will clean this up further by type-separating compressed keys, but for now ISTM that a panic is better than silently creating black-hole addresses
* does a whole pile of code cleanups