### PR TITLE
manually update nightly version to 2026-06-11.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 rust-version = "1.74.0"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-05-14"
+nightly = "nightly-2026-06-11"
 stable = "1.96.0"
 
 [features]
@@ -97,7 +97,6 @@ explicit_iter_loop = "warn"
 filter_map_next = "warn"
 flat_map_option = "warn"
 fn_params_excessive_bools = "warn"
-from_iter_instead_of_collect = "warn"
 if_not_else = "warn"
 ignored_unit_patterns = "warn"
 implicit_clone = "warn"

--- a/src/blech32/decode.rs
+++ b/src/blech32/decode.rs
@@ -257,7 +257,7 @@ impl<'s> CheckedHrpstring<'s> {
         let padding_len = fe_iter.len() * 5 % 8;
 
         if padding_len > 4 {
-            return Err(PaddingError::TooMuch)?;
+            return Err(PaddingError::TooMuch);
         }
 
         let last_fe = fe_iter.last().expect("checked above");

--- a/src/pset/map/global.rs
+++ b/src/pset/map/global.rs
@@ -174,7 +174,7 @@ impl Map for Global {
                         }
                         self.scalars.push(scalar);
                     } else {
-                        return Err(Error::InvalidKey(raw_key))?;
+                        return Err(Error::InvalidKey(raw_key).into());
                     }
                 } else if prop_key.is_pset_key()
                     && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE
@@ -182,7 +182,7 @@ impl Map for Global {
                     if prop_key.key.is_empty() && raw_value.len() == 1 {
                         self.elements_tx_modifiable_flag = Some(raw_value[0]);
                     } else {
-                        return Err(Error::InvalidKey(raw_key))?;
+                        return Err(Error::InvalidKey(raw_key).into());
                     }
                 } else {
                     match self.proprietary.entry(prop_key) {
@@ -467,7 +467,7 @@ impl Decodable for Global {
                                     }
                                     scalars.push(scalar);
                                 } else {
-                                    return Err(Error::InvalidKey(raw_key))?;
+                                    return Err(Error::InvalidKey(raw_key).into());
                                 }
                             } else if prop_key.is_pset_key()
                                 && prop_key.subtype == PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE
@@ -475,7 +475,7 @@ impl Decodable for Global {
                                 if prop_key.key.is_empty() && raw_value.len() == 1 {
                                     elements_tx_modifiable_flag = Some(raw_value[0]);
                                 } else {
-                                    return Err(Error::InvalidKey(raw_key))?;
+                                    return Err(Error::InvalidKey(raw_key).into());
                                 }
                             } else {
                                 match proprietary.entry(prop_key) {
@@ -506,7 +506,7 @@ impl Decodable for Global {
         // Mandatory fields
         let version = version.ok_or(Error::IncorrectPsetVersion)?;
         if version != 2 {
-            return Err(Error::IncorrectPsetVersion)?;
+            return Err(Error::IncorrectPsetVersion.into());
         }
         let tx_version = tx_version.ok_or(Error::MissingTxVersion)?;
         let input_count = input_count.ok_or(Error::MissingInputCount)?.0 as usize;

--- a/src/pset/map/input.rs
+++ b/src/pset/map/input.rs
@@ -688,7 +688,7 @@ impl Map for Input {
                 )?;
             }
             PSET_IN_PREVIOUS_TXID | PSET_IN_OUTPUT_INDEX => {
-                return Err(Error::DuplicateKey(raw_key))?;
+                return Err(Error::DuplicateKey(raw_key).into());
             }
             PSET_IN_SEQUENCE => {
                 impl_pset_insert_pair! {

--- a/src/pset/mod.rs
+++ b/src/pset/mod.rs
@@ -747,7 +747,7 @@ impl Decodable for PartiallySignedTransaction {
 
             // Maximum pset input size supported
             if inputs_len > 10_000 {
-                return Err(Error::TooLargePset)?;
+                return Err(Error::TooLargePset.into());
             }
 
             let mut inputs: Vec<Input> = Vec::with_capacity(inputs_len);
@@ -764,7 +764,7 @@ impl Decodable for PartiallySignedTransaction {
 
             // Maximum pset input size supported
             if outputs_len > 10_000 {
-                return Err(Error::TooLargePset)?;
+                return Err(Error::TooLargePset.into());
             }
 
             let mut outputs: Vec<Output> = Vec::with_capacity(outputs_len);


### PR DESCRIPTION
Clippy removed the `from_iter_instead_of_collect` lint due to being "problematic". I don't know that we ever used this, but we had explicitly enabled it.

Clippy also added a new `needless_return_with_question_mark` lint which fires numerous times throughout the crate.

Supercedes #274.