### PR TITLE
Automated weekly update to rustc stable (to 1.97.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.74.0"
 
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-06-11"
-stable = "1.96.0"
+stable = "1.97.1"
 
 [features]
 default = ["json-contract"]


### PR DESCRIPTION
Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action